### PR TITLE
Agent auto re-registration after CP disconnect/state loss

### DIFF
--- a/.github/SECRETS_SETUP.md
+++ b/.github/SECRETS_SETUP.md
@@ -31,6 +31,8 @@ The following secrets should already be set:
 - `CLOUDFLARE_API_TOKEN` - Cloudflare API token for tunnel management
 - `CLOUDFLARE_ACCOUNT_ID` - Cloudflare account ID
 - `CLOUDFLARE_ZONE_ID` - Cloudflare zone ID
+- `CP_MEASUREMENTS_SIGNING_KEY` - Base fallback signing key for CP measurement bundle signing
+- `STAGING_CP_MEASUREMENTS_SIGNING_KEY` / `PRODUCTION_CP_MEASUREMENTS_SIGNING_KEY` - Env-specific overrides (recommended)
 - `INTEL_API_KEY` - Intel Trust Authority API key
 - `CONTROL_PLANE_ADMIN_PASSWORD` - Plaintext admin password (for login testing)
 

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -116,6 +116,19 @@ jobs:
             -e "target_image_labels=easyenclave=managed,easyenclave_env=production,gitsha=${{ steps.vars.outputs.sha12 }}" \
             -e "source_sha=${SOURCE_SHA}"
 
+      - name: Cleanup managed production VMs via Ansible
+        shell: bash
+        env:
+          ANSIBLE_CONFIG: ansible/ansible.cfg
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          EASYENCLAVE_DOMAIN: ${{ env.EASYENCLAVE_DOMAIN }}
+        run: |
+          set -euo pipefail
+          ansible-playbook ansible/playbooks/gcp-cleanup-managed-vms.yml \
+            -e "ee_env_name=production"
+
       - name: Deploy production control plane and agent
         id: deploy
         shell: bash

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -128,6 +128,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          CP_MEASUREMENTS_SIGNING_KEY: ${{ secrets.PRODUCTION_CP_MEASUREMENTS_SIGNING_KEY || secrets.CP_MEASUREMENTS_SIGNING_KEY }}
           EASYENCLAVE_ENV: production
           EASYENCLAVE_NETWORK_NAME: ${{ steps.vars.outputs.network_name }}
           EASYENCLAVE_RELEASE_TAG: ${{ steps.vars.outputs.release_tag }}

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -230,6 +230,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          CP_MEASUREMENTS_SIGNING_KEY: ${{ secrets.STAGING_CP_MEASUREMENTS_SIGNING_KEY || secrets.CP_MEASUREMENTS_SIGNING_KEY }}
           EASYENCLAVE_ENV: staging
           EASYENCLAVE_NETWORK_NAME: ${{ needs.prep.outputs.network_name }}
           EASYENCLAVE_RELEASE_TAG: ${{ needs.prep.outputs.release_tag }}

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -213,6 +213,10 @@ jobs:
         shell: bash
         env:
           ANSIBLE_CONFIG: ansible/ansible.cfg
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          EASYENCLAVE_DOMAIN: ${{ env.EASYENCLAVE_DOMAIN }}
         run: |
           set -euo pipefail
           ansible-playbook ansible/playbooks/gcp-cleanup-managed-vms.yml \

--- a/ansible/playbooks/gcp-cleanup-managed-vms.yml
+++ b/ansible/playbooks/gcp-cleanup-managed-vms.yml
@@ -42,6 +42,106 @@
         msg: >-
           Managed instances matching '{{ cleanup_filter }}': {{ managed_instances | length }}
 
+    - name: Resolve Cloudflare cleanup inputs
+      ansible.builtin.set_fact:
+        cf_account_id: "{{ lookup('env', 'CLOUDFLARE_ACCOUNT_ID') | default('', true) }}"
+        cf_zone_id: "{{ lookup('env', 'CLOUDFLARE_ZONE_ID') | default('', true) }}"
+        cf_api_token: "{{ lookup('env', 'CLOUDFLARE_API_TOKEN') | default('', true) }}"
+        cf_domain: "{{ lookup('env', 'EASYENCLAVE_DOMAIN') | default('', true) }}"
+
+    - name: Determine Cloudflare cleanup enablement
+      ansible.builtin.set_fact:
+        cf_cleanup_enabled: >-
+          {{
+            (cf_account_id | length > 0)
+            and (cf_zone_id | length > 0)
+            and (cf_api_token | length > 0)
+            and (cf_domain | length > 0)
+          }}
+
+    - name: Extract managed agent names
+      ansible.builtin.set_fact:
+        managed_agent_names: >-
+          {{
+            managed_instances
+            | map('split')
+            | map('first')
+            | select('match', '^tdx-agent-')
+            | list
+          }}
+
+    - name: Print Cloudflare cleanup summary
+      ansible.builtin.debug:
+        msg: >-
+          Cloudflare cleanup enabled={{ cf_cleanup_enabled }} managed_agent_names={{ managed_agent_names | length }}
+      when: managed_instances | length > 0
+
+    - name: Lookup Cloudflare DNS records for managed agent hostnames
+      ansible.builtin.uri:
+        url: "https://api.cloudflare.com/client/v4/zones/{{ cf_zone_id }}/dns_records?type=CNAME&name={{ item }}.{{ cf_domain }}"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ cf_api_token }}"
+        status_code: 200
+        return_content: true
+      loop: "{{ managed_agent_names }}"
+      register: cf_dns_lookup
+      when:
+        - cf_cleanup_enabled | bool
+        - managed_agent_names | length > 0
+
+    - name: Collect Cloudflare DNS record ids
+      ansible.builtin.set_fact:
+        cf_dns_record_ids: "{{ cf_dns_lookup.results | map(attribute='json.result') | flatten | map(attribute='id') | list }}"
+      when:
+        - cf_cleanup_enabled | bool
+        - managed_agent_names | length > 0
+
+    - name: Delete Cloudflare DNS records for managed agents
+      ansible.builtin.uri:
+        url: "https://api.cloudflare.com/client/v4/zones/{{ cf_zone_id }}/dns_records/{{ item }}"
+        method: DELETE
+        headers:
+          Authorization: "Bearer {{ cf_api_token }}"
+        status_code: 200
+      loop: "{{ cf_dns_record_ids | default([]) }}"
+      when:
+        - cf_cleanup_enabled | bool
+        - (cf_dns_record_ids | default([]) | length) > 0
+
+    - name: Lookup Cloudflare tunnels for managed agents
+      ansible.builtin.uri:
+        url: "https://api.cloudflare.com/client/v4/accounts/{{ cf_account_id }}/cfd_tunnel?name={{ item }}&is_deleted=false&per_page=50"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ cf_api_token }}"
+        status_code: 200
+        return_content: true
+      loop: "{{ managed_agent_names }}"
+      register: cf_tunnel_lookup
+      when:
+        - cf_cleanup_enabled | bool
+        - managed_agent_names | length > 0
+
+    - name: Collect Cloudflare tunnel ids
+      ansible.builtin.set_fact:
+        cf_tunnel_ids: "{{ cf_tunnel_lookup.results | map(attribute='json.result') | flatten | map(attribute='id') | list }}"
+      when:
+        - cf_cleanup_enabled | bool
+        - managed_agent_names | length > 0
+
+    - name: Delete Cloudflare tunnels for managed agents
+      ansible.builtin.uri:
+        url: "https://api.cloudflare.com/client/v4/accounts/{{ cf_account_id }}/cfd_tunnel/{{ item }}"
+        method: DELETE
+        headers:
+          Authorization: "Bearer {{ cf_api_token }}"
+        status_code: 200
+      loop: "{{ cf_tunnel_ids | default([]) }}"
+      when:
+        - cf_cleanup_enabled | bool
+        - (cf_tunnel_ids | default([]) | length) > 0
+
     - name: Delete managed instance
       ansible.builtin.command:
         argv:

--- a/ansible/playbooks/gcp-control-plane-new.yml
+++ b/ansible/playbooks/gcp-control-plane-new.yml
@@ -130,6 +130,7 @@
           cloudflare_api_token: "{{ lookup('env', 'CLOUDFLARE_API_TOKEN') | default('', true) }}"
           cloudflare_account_id: "{{ lookup('env', 'CLOUDFLARE_ACCOUNT_ID') | default('', true) }}"
           cloudflare_zone_id: "{{ lookup('env', 'CLOUDFLARE_ZONE_ID') | default('', true) }}"
+          cp_measurements_signing_key: "{{ lookup('env', 'CP_MEASUREMENTS_SIGNING_KEY') | default('', true) }}"
           admin_password: "{{ admin_password_env }}"
           admin_github_logins: "{{ lookup('env', 'ADMIN_GITHUB_LOGINS') | default('', true) }}"
           admin_password_hash: "{{ lookup('env', 'ADMIN_PASSWORD_HASH') | default('', true) }}"

--- a/ansible/playbooks/gcp-control-plane-new.yml
+++ b/ansible/playbooks/gcp-control-plane-new.yml
@@ -242,8 +242,8 @@
           {{
             (cp_create_primary.rc | int != 0)
             and (resolved_cp_size == 'standard')
-            and (((cp_create_primary.stderr | default('')) ~ '\n' ~ (cp_create_primary.stdout | default('')))
-              | regex_search('C3_CPUS|CONCURRENT_OPERATIONS_QUOTA_EXCEEDED'))
+            and ((((cp_create_primary.stderr | default('')) ~ '\n' ~ (cp_create_primary.stdout | default('')))
+              | regex_search('C3_CPUS|CONCURRENT_OPERATIONS_QUOTA_EXCEEDED')) is not none)
           }}
 
     - name: Log control-plane quota fallback to tiny profile

--- a/ansible/playbooks/gcp-control-plane-new.yml
+++ b/ansible/playbooks/gcp-control-plane-new.yml
@@ -33,7 +33,7 @@
 
     - name: Resolve control-plane size
       ansible.builtin.set_fact:
-        resolved_cp_size: "{{ cp_size | lower if (cp_size | length > 0) else ('tiny' if resolved_env_name == 'staging' else 'standard') }}"
+        resolved_cp_size: "{{ cp_size | lower if (cp_size | length > 0) else 'tiny' }}"
 
     - name: Validate control-plane size
       ansible.builtin.assert:

--- a/src/bin/ee-agent/main.rs
+++ b/src/bin/ee-agent/main.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::process::{Child, Command, ExitCode, Stdio};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::cp_client_api::{AgentChallengeResponse, AgentRegisterResponse};
 use config::{AgentMode, AgentRuntimeConfig, ProvidedApp};
@@ -18,6 +18,7 @@ use easyenclave::common::error::{AppError, AppResult};
 use oci::{DockerOciRuntime, LaunchRequest, OciRuntimeEngine, PortMapping};
 use reqwest::blocking::Client;
 use reqwest::StatusCode;
+use serde::Deserialize;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
@@ -59,26 +60,92 @@ fn run_agent_mode(cfg: &AgentRuntimeConfig) -> AppResult<()> {
         cfg.intel_api_key.is_some(),
     );
 
+    let reconcile_interval_seconds = std::env::var("AGENT_CP_RECONCILE_INTERVAL_SECONDS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(30)
+        .max(5);
+    let probe_failures_before_reregister =
+        std::env::var("AGENT_CP_RECONCILE_FAILURES_BEFORE_REREGISTER")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(3)
+            .max(1);
+
+    eprintln!(
+        "ee-agent: cp reconcile interval={}s failures_before_reregister={}",
+        reconcile_interval_seconds, probe_failures_before_reregister
+    );
+
     let mut registered = register_with_retries(cfg, &cp_url, &vm_name)?;
     let mut tunnel = start_cloudflared(&registered.tunnel_token)?;
+    let mut consecutive_probe_failures: u32 = 0;
+    let mut next_reconcile = Instant::now() + Duration::from_secs(reconcile_interval_seconds);
 
     if let Some(app) = cfg.provided_app {
         run_provided_app(cfg, &runtime, app)?;
     }
 
     loop {
+        let mut cloudflared_exited = false;
         if let Some(child) = &mut tunnel {
             let maybe_status = child.try_wait().map_err(command_err)?;
             if let Some(status) = maybe_status {
                 eprintln!("ee-agent: cloudflared exited with status={status}; re-registering");
-                registered = register_with_retries(cfg, &cp_url, &vm_name)?;
-                tunnel = start_cloudflared(&registered.tunnel_token)?;
+                cloudflared_exited = true;
             }
         }
+
+        if cloudflared_exited {
+            registered = register_with_retries(cfg, &cp_url, &vm_name)?;
+            tunnel = restart_cloudflared(tunnel, &registered.tunnel_token)?;
+            consecutive_probe_failures = 0;
+        }
+
+        let now = Instant::now();
+        if now >= next_reconcile {
+            next_reconcile = now + Duration::from_secs(reconcile_interval_seconds);
+            match is_vm_registered_on_cp(&cp_url, &vm_name) {
+                Ok(true) => {
+                    if consecutive_probe_failures > 0 {
+                        eprintln!(
+                            "ee-agent: cp registration probe recovered after {} failures",
+                            consecutive_probe_failures
+                        );
+                    }
+                    consecutive_probe_failures = 0;
+                }
+                Ok(false) => {
+                    eprintln!(
+                        "ee-agent: vm_name={} missing from cp agent list; re-registering",
+                        vm_name
+                    );
+                    registered = register_with_retries(cfg, &cp_url, &vm_name)?;
+                    tunnel = restart_cloudflared(tunnel, &registered.tunnel_token)?;
+                    consecutive_probe_failures = 0;
+                }
+                Err(err) => {
+                    consecutive_probe_failures = consecutive_probe_failures.saturating_add(1);
+                    eprintln!(
+                        "ee-agent: cp registration probe failed attempt={} error={}",
+                        consecutive_probe_failures, err
+                    );
+                    if consecutive_probe_failures >= probe_failures_before_reregister {
+                        eprintln!(
+                            "ee-agent: cp probe failures reached {}; forcing re-registration",
+                            probe_failures_before_reregister
+                        );
+                        registered = register_with_retries(cfg, &cp_url, &vm_name)?;
+                        tunnel = restart_cloudflared(tunnel, &registered.tunnel_token)?;
+                        consecutive_probe_failures = 0;
+                    }
+                }
+            }
+        }
+
         thread::sleep(Duration::from_secs(10));
     }
 }
-
 fn run_control_plane_mode(cfg: &AgentRuntimeConfig) -> AppResult<()> {
     let image = cfg.control_plane_image.as_ref().ok_or_else(|| {
         AppError::Config("control-plane mode requires control_plane_image".to_string())
@@ -624,6 +691,49 @@ fn start_cloudflared(token: &str) -> AppResult<Option<Child>> {
     Ok(Some(child))
 }
 
+fn stop_cloudflared(mut child: Child) -> AppResult<()> {
+    if child.try_wait().map_err(command_err)?.is_some() {
+        return Ok(());
+    }
+
+    child.kill().map_err(command_err)?;
+    let _ = child.wait().map_err(command_err)?;
+    Ok(())
+}
+
+fn restart_cloudflared(current: Option<Child>, token: &str) -> AppResult<Option<Child>> {
+    if let Some(child) = current {
+        stop_cloudflared(child)?;
+    }
+    start_cloudflared(token)
+}
+
+fn is_vm_registered_on_cp(cp_url: &str, vm_name: &str) -> AppResult<bool> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .map_err(|e| AppError::External(format!("http client init failed: {e}")))?;
+
+    let url = format!("{}/api/agents", cp_url.trim_end_matches('/'));
+    let resp = client
+        .get(url)
+        .send()
+        .map_err(|e| AppError::External(format!("agents list request failed: {e}")))?;
+    let status = resp.status();
+    if status != StatusCode::OK {
+        let body = resp.text().unwrap_or_default();
+        return Err(AppError::External(format!(
+            "agents list failed status={} body={}",
+            status, body
+        )));
+    }
+
+    let payload: Vec<CpAgentListItem> = resp
+        .json()
+        .map_err(|e| AppError::External(format!("agents list parse failed: {e}")))?;
+    Ok(payload.iter().any(|item| item.vm_name == vm_name))
+}
+
 fn gcp_metadata_get(path: &str) -> AppResult<String> {
     let client = Client::builder()
         .timeout(Duration::from_secs(5))
@@ -656,4 +766,9 @@ fn command_err(err: std::io::Error) -> AppError {
 
 struct RegisteredAgent {
     tunnel_token: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CpAgentListItem {
+    vm_name: String,
 }

--- a/src/bin/ee-agent/main.rs
+++ b/src/bin/ee-agent/main.rs
@@ -275,6 +275,12 @@ fn build_control_plane_env(cfg: &AgentRuntimeConfig) -> Vec<(String, String)> {
     insert_mapped(
         &mut env,
         &cfg.raw_kv,
+        "cp_measurements_signing_key",
+        "CP_MEASUREMENTS_SIGNING_KEY",
+    );
+    insert_mapped(
+        &mut env,
+        &cfg.raw_kv,
         "stripe_secret_key",
         "STRIPE_SECRET_KEY",
     );

--- a/src/cp/routes/agents.rs
+++ b/src/cp/routes/agents.rs
@@ -74,7 +74,7 @@ pub async fn register(
         .create(
             &payload.vm_name,
             AgentStatus::Undeployed,
-            true,
+            false,
             payload.node_size.as_deref(),
             payload.datacenter.as_deref(),
             payload.github_owner.as_deref(),
@@ -107,7 +107,11 @@ pub async fn register(
         .await
     {
         Ok(tunnel) => tunnel,
-        Err(_) => {
+        Err(err) => {
+            eprintln!(
+                "ee-cp: agent tunnel provision failed vm_name={} agent_id={} error={}",
+                payload.vm_name, created.agent_id, err
+            );
             let _ = store.delete(created.agent_id).await;
             return Err(error_response(
                 StatusCode::BAD_GATEWAY,
@@ -126,6 +130,10 @@ pub async fn register(
         .await
         .is_err()
     {
+        eprintln!(
+            "ee-cp: failed to persist agent tunnel data vm_name={} agent_id={}",
+            payload.vm_name, created.agent_id
+        );
         let _ = state
             .tunnel
             .delete_tunnel_for_agent(&tunnel.tunnel_id, &tunnel.hostname)
@@ -138,6 +146,22 @@ pub async fn register(
         ));
     }
 
+    if let Err(err) = store.set_verified(created.agent_id, true).await {
+        eprintln!(
+            "ee-cp: failed to mark agent verified vm_name={} agent_id={} error={}",
+            payload.vm_name, created.agent_id, err
+        );
+        let _ = state
+            .tunnel
+            .delete_tunnel_for_agent(&tunnel.tunnel_id, &tunnel.hostname)
+            .await;
+        let _ = store.delete(created.agent_id).await;
+        return Err(error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "registration_failed",
+            "failed to finalize agent registration",
+        ));
+    }
     Ok(Json(AgentRegisterResponse {
         agent_id: created.agent_id,
         tunnel_token: tunnel.tunnel_token,

--- a/src/cp/stores/agent.rs
+++ b/src/cp/stores/agent.rs
@@ -174,6 +174,18 @@ impl AgentStore {
         Ok(())
     }
 
+    pub async fn set_verified(&self, agent_id: Uuid, verified: bool) -> AppResult<()> {
+        sqlx::query(
+            "UPDATE agents SET verified = ?1, updated_at = CURRENT_TIMESTAMP WHERE agent_id = ?2",
+        )
+        .bind(if verified { 1_i64 } else { 0_i64 })
+        .bind(agent_id.to_string())
+        .execute(&self.pool)
+        .await
+        .map_err(|e| AppError::External(format!("failed to update agent verified flag: {e}")))?;
+        Ok(())
+    }
+
     pub async fn set_tunnel(
         &self,
         agent_id: Uuid,


### PR DESCRIPTION
## Summary
- add periodic CP registration reconciliation in `ee-agent`
- re-register when VM is missing from `/api/agents`
- force re-registration after repeated CP probe failures
- restart `cloudflared` after successful re-registration

## Config
- `AGENT_CP_RECONCILE_INTERVAL_SECONDS` (default `30`, min `5`)
- `AGENT_CP_RECONCILE_FAILURES_BEFORE_REREGISTER` (default `3`, min `1`)

## Validation
- `cargo test --bin ee-agent`
- `cargo fmt --check`
