### PR TITLE
feat: bootable TDX VM image pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,18 @@ target/
 
 # VM images and build outputs
 infra/output/
+image/output/
+image/mkosi.extra/
+image/easyenclave
+image/easyenclave.raw
+image/easyenclave.root-*.raw
+image/easyenclave.vmlinuz
+image/easyenclave.initrd
+image/easyenclave.efi
+image/easyenclave.manifest
+image/easyenclave-uki.tar.gz
+image/initrd-minimal.cpio.gz
+image/disk.raw
 *.qcow2
 *.iso
 

--- a/image/Makefile
+++ b/image/Makefile
@@ -1,0 +1,77 @@
+# EasyEnclave VM Image Build
+#
+# Builds a bootable TDX VM image with easyenclave as PID 1.
+# Boots via Unified Kernel Image (UKI): kernel + initrd + cmdline in one
+# EFI binary. No bootloader. One file = one measurement.
+#
+# Workflow:
+#   1. mkosi Format=directory → produces populated rootfs tree
+#   2. mkfs.ext4 -d → packs the tree into an ext4 image
+#   3. mkinitrd.sh → builds minimal initrd with nvme+dm-verity modules
+#   4. ukify → builds UKI from host kernel + initrd + cmdline
+#   5. assemble-disk.sh → GPT disk with ESP (UKI) + root partitions
+#
+# We use Format=directory because Format=disk has a bug where the split
+# partition artifacts come out empty. Assembling the disk manually also
+# gives us full control over partition layout.
+#
+# TODO: add dm-verity back once base boot works.
+#
+# Prerequisites: mkosi 25+, cargo, busybox-static, e2fsprogs, mtools,
+#   systemd-boot-efi (for the EFI stub), systemd-ukify
+# Usage:
+#   make build    - Build the image
+#   make clean    - Remove build artifacts
+
+REPO_ROOT := ..
+EXTRA_BIN := mkosi.extra/usr/local/bin
+OUTPUT_DIR := output
+EE_BIN := $(REPO_ROOT)/target/release/easyenclave
+EFI_STUB := /usr/lib/systemd/boot/efi/linuxx64.efi.stub
+KVER ?= $(shell uname -r)
+
+.PHONY: build clean
+
+build: $(EXTRA_BIN)/easyenclave
+	chmod +x mkosi.postinst.chroot mkosi.finalize mkinitrd.sh assemble-disk.sh
+	mkdir -p $(OUTPUT_DIR)
+	# 1. Build rootfs as a directory (Format=disk has a bug where the split
+	#    partition artifact is empty — directory output is populated correctly).
+	sudo mkosi build --force --format directory
+	sudo du -sh easyenclave/
+	# 2. Pack the directory into a plain ext4 image.
+	#    256MB is enough for ~81MB of content with room for logs/state.
+	rm -f $(OUTPUT_DIR)/rootfs.img
+	dd if=/dev/zero of=$(OUTPUT_DIR)/rootfs.img bs=1M count=256 status=none
+	sudo mkfs.ext4 -F -L root -d easyenclave $(OUTPUT_DIR)/rootfs.img 2>&1 | tail -3
+	# 3. Kernel cmdline: direct-mount root, no dm-verity yet.
+	echo "root=/dev/nvme0n1p2 console=ttyS0,115200" > $(OUTPUT_DIR)/easyenclave.cmdline
+	# 4. Minimal initrd (nvme + dm-verity + deps via modprobe)
+	sudo bash mkinitrd.sh $(OUTPUT_DIR)/easyenclave.initrd $(KVER)
+	# 5. Host kernel
+	sudo cp /boot/vmlinuz-$(KVER) $(OUTPUT_DIR)/easyenclave.vmlinuz
+	sudo chmod 644 $(OUTPUT_DIR)/easyenclave.vmlinuz
+	# 6. Build UKI
+	ukify build \
+		--stub $(EFI_STUB) \
+		--linux $(OUTPUT_DIR)/easyenclave.vmlinuz \
+		--initrd $(OUTPUT_DIR)/easyenclave.initrd \
+		--cmdline @$(OUTPUT_DIR)/easyenclave.cmdline \
+		--output $(OUTPUT_DIR)/easyenclave.efi
+	# 7. Assemble bootable GPT disk: ESP (with UKI) + rootfs
+	bash assemble-disk.sh $(OUTPUT_DIR)
+	@echo ""
+	@echo "Build complete:"
+	@ls -lh $(OUTPUT_DIR)/ 2>/dev/null || true
+
+$(EE_BIN):
+	cargo build --manifest-path $(REPO_ROOT)/Cargo.toml --release
+
+$(EXTRA_BIN)/easyenclave: $(EE_BIN)
+	mkdir -p $(EXTRA_BIN)
+	cp $(EE_BIN) $(EXTRA_BIN)/easyenclave
+	chmod 0755 $(EXTRA_BIN)/easyenclave
+
+clean:
+	sudo rm -rf mkosi.extra $(OUTPUT_DIR) easyenclave easyenclave.raw easyenclave.root-*.raw easyenclave.vmlinuz easyenclave.initrd easyenclave.efi easyenclave.manifest easyenclave-image.tar.gz disk.raw
+	sudo mkosi clean 2>/dev/null || true

--- a/image/assemble-disk.sh
+++ b/image/assemble-disk.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Assemble a bootable GPT disk from:
+#   - UKI (kernel+initrd+cmdline as one EFI binary) → ESP partition
+#   - rootfs.img (populated ext4) → root partition
+#
+# Layout:
+#   GPT header + 1MB alignment
+#   Partition 1: ESP (FAT32, 64MB)  — contains /EFI/BOOT/BOOTX64.EFI (the UKI)
+#   Partition 2: root (ext4)        — populated rootfs
+#
+# TDX boot flow:
+#   UEFI firmware → ESP/EFI/BOOT/BOOTX64.EFI (UKI) → kernel + initrd → init → easyenclave
+set -euo pipefail
+
+OUTPUT_DIR="${1:-.}"
+UKI="${OUTPUT_DIR}/easyenclave.efi"
+ROOT_IMG="${OUTPUT_DIR}/rootfs.img"
+DISK="${OUTPUT_DIR}/easyenclave.root.raw"
+
+[ -f "$UKI" ] || { echo "No UKI at $UKI"; exit 1; }
+[ -f "$ROOT_IMG" ] || { echo "No rootfs at $ROOT_IMG"; exit 1; }
+
+# ESP with the UKI as the default boot entry
+ESP_SIZE=64  # MB
+ESP_IMG=$(mktemp)
+dd if=/dev/zero of="$ESP_IMG" bs=1M count=$ESP_SIZE 2>/dev/null
+mkfs.vfat -F 32 "$ESP_IMG" >/dev/null
+mmd -i "$ESP_IMG" ::EFI ::EFI/BOOT
+mcopy -i "$ESP_IMG" "$UKI" ::EFI/BOOT/BOOTX64.EFI
+
+# Partition layout
+ESP_BYTES=$((ESP_SIZE * 1024 * 1024))
+ROOT_BYTES=$(stat -c%s "$ROOT_IMG")
+TOTAL_BYTES=$((1024*1024 + ESP_BYTES + ROOT_BYTES + 1024*1024))
+
+dd if=/dev/zero of="$DISK" bs=1 count=0 seek=$TOTAL_BYTES 2>/dev/null
+
+ESP_START=2048  # sector 2048 = 1MB aligned
+ESP_SECTORS=$((ESP_BYTES / 512))
+ROOT_START=$((ESP_START + ESP_SECTORS))
+ROOT_SECTORS=$((ROOT_BYTES / 512))
+
+sfdisk "$DISK" <<EOF >/dev/null
+label: gpt
+sector-size: 512
+${ESP_START},${ESP_SECTORS},U
+${ROOT_START},${ROOT_SECTORS},4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709
+EOF
+
+# Write partition contents
+dd if="$ESP_IMG" of="$DISK" bs=512 seek=$ESP_START conv=notrunc 2>/dev/null
+dd if="$ROOT_IMG" of="$DISK" bs=512 seek=$ROOT_START conv=notrunc 2>/dev/null
+
+rm -f "$ESP_IMG"
+
+SIZE=$(du -h "$DISK" | cut -f1)
+echo "Bootable disk assembled: $DISK ($SIZE)"
+echo "  ESP:  ${ESP_SIZE}MB (UKI at EFI/BOOT/BOOTX64.EFI)"
+echo "  Root: $((ROOT_BYTES / 1024 / 1024))MB (populated ext4)"

--- a/image/mkinitrd.sh
+++ b/image/mkinitrd.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# Build a minimal initrd for easyenclave TDX VMs.
+# Just enough to: load dm-verity/virtio modules, mount root, exec /sbin/init.
+# ~2-5MB instead of mkosi's default ~300MB systemd initrd.
+set -euo pipefail
+
+OUTFILE="${1:-initrd.cpio.gz}"
+KVER="${2:?Usage: mkinitrd.sh <outfile> <kernel-version>}"
+MOD_SRC="/lib/modules/$KVER"
+
+[ -d "$MOD_SRC" ] || { echo "FATAL: $MOD_SRC not found"; exit 1; }
+echo "Building initrd for kernel $KVER (modules: $MOD_SRC)"
+
+WORKDIR=$(mktemp -d)
+trap "rm -rf $WORKDIR" EXIT
+
+mkdir -p "$WORKDIR"/{bin,sbin,lib,lib64,dev,proc,sys,mnt/root,etc}
+
+# Busybox as the userspace (static, ~1MB)
+if command -v busybox >/dev/null 2>&1; then
+    cp "$(which busybox)" "$WORKDIR/bin/busybox"
+else
+    # Download static busybox
+    curl -fsSL -o "$WORKDIR/bin/busybox" \
+        "https://busybox.net/downloads/binaries/1.35.0-x86_64-linux-musl/busybox"
+fi
+chmod +x "$WORKDIR/bin/busybox"
+
+# Symlink essential commands
+for cmd in sh mount umount switch_root mkdir cat echo sleep modprobe insmod; do
+    ln -s busybox "$WORKDIR/bin/$cmd"
+done
+
+# Copy modules + full transitive dep tree using modprobe's resolution.
+# modprobe --show-depends is the source of truth — don't hand-list deps.
+# Preserve the kernel/... path structure so modules.dep entries still resolve
+# in the initrd.
+MODDIR="$WORKDIR/lib/modules/$KVER"
+mkdir -p "$MODDIR"
+for top in dm-verity nvme tdx-guest tsm-report; do
+    modprobe --show-depends --set-version "$KVER" "$top" 2>/dev/null \
+        | awk '/^insmod/ { print $2 }' \
+        | while read -r src; do
+            [ -z "$src" ] && continue
+            rel=${src#"$MOD_SRC/"}
+            dst="$MODDIR/$rel"
+            mkdir -p "$(dirname "$dst")"
+            cp --update=none "$src" "$dst"
+        done
+done
+
+# Generate modules.dep inside the initrd so `modprobe` works at runtime
+depmod -b "$WORKDIR" "$KVER"
+
+# veritysetup for dm-verity (from cryptsetup-bin)
+if command -v veritysetup >/dev/null 2>&1; then
+    cp "$(which veritysetup)" "$WORKDIR/sbin/"
+    # Copy its library deps
+    ldd "$(which veritysetup)" 2>/dev/null | grep -o '/[^ ]*' | while read -r lib; do
+        dir="$WORKDIR/$(dirname "$lib")"
+        mkdir -p "$dir"
+        cp -n "$lib" "$dir/" 2>/dev/null || true
+    done
+fi
+
+# Init script
+cat > "$WORKDIR/init" <<'INIT'
+#!/bin/sh
+# Minimal init: load modules, set up dm-verity, mount root, switch_root.
+
+mount -t proc proc /proc
+mount -t sysfs sysfs /sys
+mount -t devtmpfs devtmpfs /dev
+
+# Parse kernel cmdline
+ROOTHASH=""
+ROOT_DATA=""
+ROOT_HASH=""
+for param in $(cat /proc/cmdline); do
+    case "$param" in
+        roothash=*) ROOTHASH="${param#roothash=}" ;;
+        systemd.verity_root_data=*) ROOT_DATA="${param#systemd.verity_root_data=}" ;;
+        systemd.verity_root_hash=*) ROOT_HASH="${param#systemd.verity_root_hash=}" ;;
+        root=*) ROOT_DATA="${param#root=}" ;;
+    esac
+done
+
+# Load kernel modules via modprobe — uses modules.dep to resolve transitive
+# deps automatically. Kernel built-ins (ext4, dm-mod, virtio_blk, crc32c) are
+# already present.
+modprobe dm-verity
+modprobe nvme
+# TDX attestation: tdx_guest provides the /dev/tdx_guest ioctl, tsm_report
+# provides the configfs-tsm interface at /sys/kernel/config/tsm/report.
+# Both are kernel modules (CONFIG_TDX_GUEST_DRIVER=m, CONFIG_TSM_REPORTS=m).
+modprobe tdx_guest 2>/dev/null || true
+modprobe tsm_report 2>/dev/null || true
+
+# Try NVMe naming if virtio paths don't exist
+if [ ! -e "$ROOT_DATA" ]; then
+    ROOT_DATA=$(echo "$ROOT_DATA" | sed 's|/dev/vda|/dev/nvme0n1p|')
+    ROOT_HASH=$(echo "$ROOT_HASH" | sed 's|/dev/vda|/dev/nvme0n1p|')
+fi
+
+# Wait for block devices (NVMe needs time to probe after module load)
+echo "Waiting for $ROOT_DATA${ROOT_HASH:+ and $ROOT_HASH}..."
+for i in $(seq 1 30); do
+    if [ -e "$ROOT_DATA" ]; then
+        [ -z "$ROOT_HASH" ] || [ -e "$ROOT_HASH" ] && break
+    fi
+    sleep 1
+done
+[ -e "$ROOT_DATA" ] || { echo "FATAL: $ROOT_DATA not found after 30s"; ls /dev/nvme* /dev/vd* 2>/dev/null; exec /bin/sh; }
+
+if [ -n "$ROOTHASH" ] && [ -n "$ROOT_DATA" ] && [ -n "$ROOT_HASH" ] && command -v veritysetup >/dev/null; then
+    # dm-verity: cryptographically verified root
+    veritysetup open "$ROOT_DATA" verity-root "$ROOT_HASH" "$ROOTHASH" || {
+        echo "FATAL: dm-verity setup failed"
+        exec /bin/sh
+    }
+    mount -o ro /dev/mapper/verity-root /mnt/root
+elif [ -n "$ROOT_DATA" ]; then
+    # Fallback: direct mount (no verity)
+    mount -o ro "$ROOT_DATA" /mnt/root
+else
+    echo "FATAL: no root= or roothash= in cmdline"
+    exec /bin/sh
+fi
+
+# Switch to the real root and exec easyenclave
+umount /proc /sys
+exec switch_root /mnt/root /sbin/init
+INIT
+chmod +x "$WORKDIR/init"
+
+# Create the cpio archive
+(cd "$WORKDIR" && find . | cpio -o -H newc 2>/dev/null) | gzip -9 > "$OUTFILE"
+
+SIZE=$(du -h "$OUTFILE" | cut -f1)
+echo "Initrd built: $OUTFILE ($SIZE)"

--- a/image/mkosi.conf
+++ b/image/mkosi.conf
@@ -1,0 +1,53 @@
+# EasyEnclave TDX VM Image
+#
+# Minimal sealed image: easyenclave as PID 1, dm-verity protected rootfs.
+# No systemd, no SSH, no login shell, no container daemon, no bootloader.
+# Boots via Unified Kernel Image (UKI): kernel + initrd + cmdline in one
+# EFI binary. One file, one measurement.
+#
+# Usage: cd image && make build
+
+[Distribution]
+Distribution=ubuntu
+Release=noble
+
+[Output]
+Format=disk
+ImageId=easyenclave
+CompressOutput=false
+SplitArtifacts=true
+Seed=e4570c1a-2024-4e45-a8e0-c1a0e0000001
+
+[Content]
+# No linux-image-generic — we use the host's kernel (copied via Makefile
+# into mkosi.extra/) so the initrd modules always match.
+Packages=
+    kmod
+    iproute2
+    ca-certificates
+    uidmap
+
+# Only include kernel modules needed for TDX boot.
+KernelModulesInitrdInclude=
+    dm-verity
+    dm-mod
+    ext4
+    virtio_blk
+    virtio_net
+    virtio_pci
+    virtio_scsi
+    virtio_console
+    overlay
+KernelModulesInitrdExclude=re:.*
+
+WithRecommends=false
+CleanPackageMetadata=true
+SkeletonTrees=mkosi.skeleton
+PostInstallationScripts=mkosi.postinst.chroot
+FinalizeScripts=mkosi.finalize
+ExtraTrees=mkosi.extra
+SourceDateEpoch=0
+WithNetwork=false
+
+[Validation]
+SignExpectedPcr=false

--- a/image/mkosi.finalize
+++ b/image/mkosi.finalize
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Cleanup for reproducible rootfs.
+set -euo pipefail
+ROOT="${1:-${BUILDROOT:-/buildroot}}"
+rm -f "$ROOT/var/cache/ldconfig/aux-cache"
+find "$ROOT/var/log" -type f -delete 2>/dev/null || true

--- a/image/mkosi.postinst.chroot
+++ b/image/mkosi.postinst.chroot
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Post-install: symlink easyenclave as PID 1, set up dirs.
+# No kernel or modules in the rootfs — kernel lives in the UKI, and
+# easyenclave doesn't load modules post-boot.
+set -euo pipefail
+
+# easyenclave as PID 1
+ln -sf /usr/local/bin/easyenclave /sbin/init
+
+# Required dirs
+mkdir -p /etc/easyenclave /var/lib/easyenclave /mnt/config
+
+echo "[mkosi.postinst] Done."

--- a/image/mkosi.repart/10-root.conf
+++ b/image/mkosi.repart/10-root.conf
@@ -1,0 +1,5 @@
+[Partition]
+Type=root
+Format=ext4
+SizeMinBytes=512M
+SizeMaxBytes=512M

--- a/image/mkosi.skeleton/etc/fstab
+++ b/image/mkosi.skeleton/etc/fstab
@@ -1,0 +1,2 @@
+# Root is mounted read-only via dm-verity by the initrd.
+# No other mounts — easyenclave's init.rs handles /proc /sys /dev /run /tmp.

--- a/image/mkosi.skeleton/etc/hostname
+++ b/image/mkosi.skeleton/etc/hostname
@@ -1,0 +1,1 @@
+easyenclave


### PR DESCRIPTION
## Summary

Builds a sealed easyenclave TDX VM image that boots via Unified Kernel Image (UKI) on GCP confidential compute. Verified booting on c3-standard-4 with TDX: kernel → initrd → rootfs → easyenclave as PID 1 → attestation backend detected → agent socket listening.

## Pipeline (`image/Makefile`)

1. **mkosi `Format=directory`** builds the rootfs tree (Ubuntu noble + kmod + iproute2 + ca-certificates + uidmap + easyenclave binary). \`/sbin/init\` symlinks to \`/usr/local/bin/easyenclave\` so \`switch_root\` runs easyenclave as PID 1 directly. No systemd started, no SSH, no login shell.

   *\`Format=disk\` has a bug in mkosi 26 where the split rootfs partition comes out empty — \`Format=directory\` produces a populated tree we can pack manually.*

2. **\`mkfs.ext4 -d\`** packs the rootfs tree into a plain ext4 image (256MB).

3. **\`mkinitrd.sh\`** builds a minimal initrd (~6.7MB). busybox + kernel modules + modules.dep. Uses \`modprobe --show-depends\` on the host to resolve the full transitive dep tree — no hand-listed deps. *(The previous approach missed \`hkdf\`, which broke the nvme-auth → nvme-core → nvme chain.)*

4. **\`ukify\`** builds the Unified Kernel Image — host kernel + initrd + cmdline → single PE binary (~24MB). One file = one boot measurement.

5. **\`assemble-disk.sh\`** builds a GPT disk: ESP (64MB FAT32 with the UKI at \`/EFI/BOOT/BOOTX64.EFI\`) + root partition (ext4). UEFI firmware finds and executes the UKI directly — no bootloader.

## Build-host requirement

The host kernel version must be installed in \`/lib/modules\`. The Makefile uses \`KVER ?= \$(shell uname -r)\` and copies \`/boot/vmlinuz-\$KVER\` into the UKI, keeping image kernel + initrd modules exactly in sync.

## Usage

\`\`\`bash
cd image && make build
# Produces output/easyenclave.root.raw
# Upload to GCP as an image, boot with --confidential-compute-type=TDX
\`\`\`

## Verified boot (GCP eestaging)

Serial console shows the complete boot chain:

\`\`\`
Run /init as init process
nvme nvme0: pci function 0000:00:04.0
nvme0n1: p1 p2
EXT4-fs (nvme0n1p2): mounted filesystem ... ro
easyenclave: running as PID 1 -- sealed VM init
easyenclave: init: mounted /proc
easyenclave: init: mounted /sys
easyenclave: init: mounted /dev
easyenclave: init: mounted /tmp
easyenclave: init: mounted /run
easyenclave: init: mounted /var/lib/easyenclave (tmpfs, writable)
easyenclave: init complete
easyenclave: attestation backend: tdx
easyenclave: listening on /var/lib/easyenclave/agent.sock
\`\`\`

## Out of scope (follow-up PRs)

- dm-verity root (mkosi \`Format=disk\` bug blocks the populated verity artifact; the repart config is here but \`Verity=data\` is disabled for now)
- UKI signing for Secure Boot
- Attestation verification against a known-good measurement database
- Sealing secrets (CF tokens, etc.) to the boot measurement