### PR TITLE
ci: auth via GCP Workload Identity Federation

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -164,6 +164,7 @@ jobs:
     environment: release
     permissions:
       contents: write
+      id-token: write   # mint GitHub OIDC token for GCP WIF
     steps:
       - uses: actions/checkout@v4
 
@@ -172,9 +173,15 @@ jobs:
           name: easyenclave-image
           path: image/output
 
+      # GCP Workload Identity Federation — no stored SA key. The GH OIDC
+      # token is traded for a short-lived GCP access token via the pool
+      # at projects/779946350556/.../github-actions-pool, which impersonates
+      # easyenclave-github-provisioner. Principal is constrained by the
+      # provider's attribute condition (assertion.repository == this repo).
       - uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+          workload_identity_provider: 'projects/779946350556/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
+          service_account: 'easyenclave-github-provisioner@easyenclave.iam.gserviceaccount.com'
 
       - uses: google-github-actions/setup-gcloud@v2
 
@@ -346,10 +353,14 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      contents: read
+      id-token: write   # mint GitHub OIDC token for GCP WIF
     steps:
       - uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+          workload_identity_provider: 'projects/779946350556/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
+          service_account: 'easyenclave-github-provisioner@easyenclave.iam.gserviceaccount.com'
 
       - uses: google-github-actions/setup-gcloud@v2
 


### PR DESCRIPTION
## Summary

- Replace stored `GCP_SERVICE_ACCOUNT_KEY` with GitHub Actions OIDC via GCP Workload Identity Federation
- `release` and `smoke-test` jobs now mint a short-lived OIDC JWT (`id-token: write`) and trade it for a GCP access token by impersonating `easyenclave-github-provisioner` through the pre-existing `github-actions-pool` → `github-provider`
- Provider's attribute condition already constrains to `assertion.repository == 'easyenclave/easyenclave'`, and the SA binding is scoped to the same principal set — only workflows in this repo can auth

## Why

No stored credentials to rotate or leak. WIF auth is scoped per-request by GitHub OIDC claims (repo, ref, workflow). Matches the canonical GitHub Actions → GCP pattern.

## GCP infra changes (already applied)

- Added \`roles/iam.workloadIdentityUser\` binding on \`easyenclave-github-provisioner\` for \`principalSet://.../attribute.repository/easyenclave/easyenclave\`

## Test plan

- [ ] PR merged → next push to main runs \`image.yml\`
- [ ] \`release\` job → OIDC exchange → GCS upload + GCE image create succeed
- [ ] \`smoke-test\` job → OIDC exchange → TDX VM boot verifies
- [ ] Delete \`GCP_SERVICE_ACCOUNT_KEY\` repo secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)