### PR TITLE
feat(init): read boot config from GCE instance metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tokio",
+ "ureq",
  "uuid",
 ]
 
@@ -1101,6 +1102,18 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "url",
+]
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "process", "rt-multi-thread", "signal", "time", "fs", "net", "io-util"] }
+# ureq: tiny synchronous HTTP client for GCE metadata fetch at boot
+# (called from maybe_init, which is sync). No TLS features — GCE
+# metadata endpoint is plain HTTP at 169.254.169.254.
+ureq = { version = "2", default-features = false }
 uuid = { version = "1", features = ["serde", "v4"] }
 
 [build-dependencies]

--- a/src/init.rs
+++ b/src/init.rs
@@ -106,6 +106,13 @@ pub fn maybe_init() {
             .status();
     }
 
+    // GCE instance metadata: fetch the `ee-config` attribute and apply
+    // each key as an env var. This is the per-VM boot-config path for
+    // easyenclave VMs on GCP — gcloud passes it via
+    //   --metadata-from-file=ee-config=<path to JSON>
+    // Non-GCE hosts fail silently (no metadata server reachable).
+    fetch_gce_metadata_config();
+
     // Set up networking
     let ip_bin = "/sbin/ip";
     let _ = std::process::Command::new(ip_bin)
@@ -170,6 +177,50 @@ fn nix_mount(src: &str, target: &str, fstype: &str) -> Result<(), String> {
 
 fn nix_mount_ro(src: &str, target: &str, fstype: &str) -> Result<(), String> {
     nix_mount_flags(src, target, fstype, libc::MS_RDONLY)
+}
+
+/// Fetch `ee-config` from GCE instance metadata and apply each entry
+/// as an env var. Expected body is a JSON object of `{ "KEY": "VALUE", ... }`.
+/// In particular, setting `"EE_BOOT_WORKLOADS"` here (as a stringified
+/// JSON array) is how you get easyenclave to deploy workloads at boot
+/// on a GCE VM — no secondary disk needed.
+///
+/// On non-GCE hosts, or if the attribute isn't set, fail silently.
+fn fetch_gce_metadata_config() {
+    const URL: &str = "http://169.254.169.254/computeMetadata/v1/instance/attributes/ee-config";
+    let body = match ureq::get(URL)
+        .set("Metadata-Flavor", "Google")
+        .timeout(std::time::Duration::from_secs(2))
+        .call()
+    {
+        Ok(resp) => match resp.into_string() {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("easyenclave: init: gce-meta read body: {e}");
+                return;
+            }
+        },
+        Err(_) => {
+            // Not on GCE (connection refused / timeout), or attribute
+            // not set (404). Nothing to do.
+            return;
+        }
+    };
+
+    let map: std::collections::HashMap<String, String> = match serde_json::from_str(&body) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("easyenclave: init: gce-meta ee-config parse error: {e}");
+            return;
+        }
+    };
+
+    for k in map.keys() {
+        eprintln!("easyenclave: init: gce-meta env {k}=<redacted>");
+    }
+    for (k, v) in map {
+        std::env::set_var(k, v);
+    }
 }
 
 fn nix_mount_flags(


### PR DESCRIPTION
## Summary

Add a fourth boot-config source to easyenclave's `maybe_init()`: GCE instance metadata attribute `ee-config`.

## Why

The other three sources (kernel cmdline `ee.*`, secondary virtio disk `/agent.env`, process env) don't fit well for passing per-VM workload specs from `gcloud compute instances create`:
- **Kernel cmdline** is baked into the UKI at build time — not per-VM-configurable
- **Secondary disk** requires orchestrating a separate GCE disk per VM (create, populate, upload, attach) — lots of scaffolding
- **Process env** is just the inherited env, no per-VM overrides

GCE instance metadata is the canonical mechanism. Callers pass a JSON blob as `--metadata-from-file=ee-config=...`, and easyenclave fetches it via `http://169.254.169.254/computeMetadata/v1/instance/attributes/ee-config` at boot and applies each entry as an env var. In particular, setting `EE_BOOT_WORKLOADS` to a stringified JSON array triggers boot-time workload deployment through the existing code path.

## How

- New sync helper `fetch_gce_metadata_config()` in `src/init.rs`
- Uses `ureq` (sync, tiny, no TLS — GCE metadata is plain HTTP on 169.254.169.254)
- Called from `maybe_init()` right after the existing secondary-disk read
- Fails silently on non-GCE hosts (connection refused, timeout)

## Next up (separate PRs)

This is PR 1 of 3 to migrate dd's management VMs (`app-staging.devopsdefender.com`, `app.devopsdefender.com`) from stock Ubuntu to easyenclave-sealed images. Once this merges and a new `easyenclave-<sha>` image lands, PR 2 adds Dockerfiles for dd-register/dd-web and PR 3 rewrites dd's `scripts/gcp-deploy.sh` to boot from the sealed image with `ee-config` metadata.

## Test plan

- [ ] Cargo build + clippy + fmt clean (already verified locally)
- [ ] PR CI green
- [ ] Post-merge: new image builds, rotation happens
- [ ] Smoke test: boot a VM with `--metadata-from-file=ee-config=/tmp/test.json` where `test.json` = `{"EE_BOOT_WORKLOADS":"[{\"image\":\"docker.io/library/busybox\",\"app_name\":\"smoke\",\"cmd\":[\"sh\",\"-c\",\"echo hello; sleep 3600\"]}]"}`, verify via serial console that easyenclave logs `gce-meta env EE_BOOT_WORKLOADS=<redacted>` and the busybox workload runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)