### PR TITLE
docs: drop stale podman refs + fix libseccomp ci/runtime linking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # libseccomp-dev: required to link libcontainer (youki) — the
+      # Rust-native container runtime. Same apt dep as image.yml.
+      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libseccomp-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ src/
 ├── config.rs         Config from JSON file + env overlays
 ├── socket.rs         Unix socket server, newline-delimited JSON (7 methods)
 ├── workload.rs       Deploy/stop/list — container + process lifecycle
-├── container.rs      Bollard Docker/Podman (pull, run, exec, stop, logs)
+├── container.rs      Rust-native OCI runtime (libcontainer + oci-distribution): pull, run, exec, stop, logs
 ├── process.rs        Spawn, kill, liveness
 └── attestation/
     ├── mod.rs         AttestationBackend trait + detect() — errors if no TDX

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ src/
 ├── config.rs         Config from file + env overlays
 ├── socket.rs         Unix socket server (7 methods)
 ├── workload.rs       Deploy/stop/list, container + process lifecycle
-├── container.rs      Bollard Docker/Podman management
+├── container.rs      Rust-native OCI runtime (libcontainer + oci-distribution)
 ├── process.rs        Spawn, kill, liveness
 └── attestation/
     ├── mod.rs         Backend trait + TDX detection (no insecure fallback)

--- a/image/mkosi.conf
+++ b/image/mkosi.conf
@@ -29,6 +29,7 @@ Packages=
     iproute2
     ca-certificates
     uidmap
+    libseccomp2
 
 # Only include kernel modules needed for TDX boot.
 KernelModulesInitrdInclude=

--- a/www/index.html
+++ b/www/index.html
@@ -37,7 +37,7 @@
       <div class="card"><div class="ic">&#x1f50c;</div><h3>Unix Socket API</h3><p>Newline-delimited JSON over <code>/var/lib/easyenclave/agent.sock</code>. Deploy, attest, exec, monitor &mdash; all through one socket. No HTTP server in the enclave.</p></div>
       <div class="card"><div class="ic">&#x1f6e1;</div><h3>No Networking</h3><p>The runtime itself has zero networking code. Workloads handle their own connectivity. Minimal attack surface &mdash; the enclave boundary is tight.</p></div>
       <div class="card"><div class="ic">&#x2705;</div><h3>TDX Attestation</h3><p>Generate cryptographic quotes via configfs-tsm. Prove your code is running unmodified on real TDX hardware. Supports nonce-based fresh attestation.</p></div>
-      <div class="card"><div class="ic">&#x1f433;</div><h3>Containers + Processes</h3><p>Deploy Docker/Podman containers or bare processes. Post-deploy exec commands run inside containers after start. Same API for both.</p></div>
+      <div class="card"><div class="ic">&#x1f433;</div><h3>Containers + Processes</h3><p>Deploy OCI containers (pulled and run directly by a Rust-native runtime &mdash; no podman, no docker daemon) or bare processes. Post-deploy exec commands run inside containers after start. Same API for both.</p></div>
       <div class="card"><div class="ic">&#x1f4dc;</div><h3>MIT Open Source</h3><p>Read every line. Audit every build. The enclave runtime is fully open, fully auditable. Built for production confidential computing workloads.</p></div>
     </div>
   </div>
@@ -48,7 +48,7 @@
     <h2>How It Works</h2>
     <p class="sub">Boot a TDX VM with EasyEnclave as PID 1. Connect via unix socket. Deploy workloads.</p>
     <div class="steps">
-      <div class="step"><div class="sn">1</div><div><h3>Boot</h3><p>The TDX VM starts with EasyEnclave as its init process. It mounts filesystems, loads config, enables podman, and starts listening on the unix socket.</p></div></div>
+      <div class="step"><div class="sn">1</div><div><h3>Boot</h3><p>The TDX VM starts with EasyEnclave as its init process. It mounts filesystems, loads config, and starts listening on the unix socket. The container runtime is compiled in &mdash; no external daemon to start.</p></div></div>
       <div class="step"><div class="sn">2</div><div><h3>Connect</h3><p>Your client connects to <code>/var/lib/easyenclave/agent.sock</code>. Send JSON, get JSON back. No HTTP overhead.</p></div></div>
       <div class="step"><div class="sn">3</div><div><h3>Deploy</h3><p>Send a deploy request with an image or command. EasyEnclave pulls the image, starts the container, runs post-deploy commands. All tracked with status and logs.</p></div></div>
       <div class="step"><div class="sn">4</div><div><h3>Attest</h3><p>Request a TDX attestation quote with an optional nonce. The hardware generates a cryptographic proof that the exact measured code is running inside the sealed VM.</p></div></div>
@@ -75,7 +75,7 @@
  |           handles its own networking
  |
  +-- <span class="g">attestation</span>: configfs-tsm (/sys/kernel/config/tsm/report)
- +-- <span class="g">containers</span>: podman socket (/run/podman/podman.sock)
+ +-- <span class="g">containers</span>: libcontainer + oci-distribution (compiled into easyenclave)
 </pre>
     </div>
   </div>


### PR DESCRIPTION
## Summary

easyenclave#46 swapped the container runtime from bollard+podman to libcontainer + oci-distribution, but left three doc surfaces claiming the old architecture:

- **README.md** source tree: `container.rs      Bollard Docker/Podman management`
- **CLAUDE.md** source tree: same line
- **www/index.html** (landing page): 3 spots
  - feature card: "Docker/Podman containers"
  - "How It Works" step 1: "enables podman"
  - architecture diagram: "containers: podman socket (/run/podman/podman.sock)"

All updated to reflect reality: **OCI containers via libcontainer + oci-distribution, no external daemon, runtime compiled into the easyenclave binary.**

## Local verification

```
cargo build --release               # -Dwarnings clean
cargo clippy --all-targets          # -Dwarnings clean
cargo fmt --check                   # clean
```

Grep after this PR — only intentional negations remain:

```
./src/container.rs:3://! No Docker/Podman daemon needed. Pulls OCI images directly from registries
./www/index.html:40:... no podman, no docker daemon ...
./image/mkosi.conf:4:# No systemd, no SSH, no login shell, no podman, no docker
```

## In flight downstream

- **easyenclave#46 already merged.** `image.yml` on main just built `easyenclave-fd10860d28d4` — this is the **first CI build of the libcontainer code**, and it compiled + linked with the `libseccomp-dev` apt addition.
- **build ✅, release ✅, smoke-test in progress** as of this edit.
- Next step after smoke-test passes: grant `compute.imageUser` on the new image to the eestaging SAs, update `dd/scripts/gcp-deploy.sh` pin via a small PR, re-run dd staging-deploy → first time container workloads actually run through libcontainer end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
