### PR TITLE
feat: DHCP at init + local TDX dev flow via libvirt

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,34 @@ Newline-delimited JSON over `/var/lib/easyenclave/agent.sock`:
 | `EE_DATA_DIR` | `/var/lib/easyenclave` | Data directory |
 | `EE_BOOT_WORKLOADS` | (none) | JSON array of boot workloads |
 
+## Run locally in TDX (libvirt)
+
+On a TDX-capable host (check `cat /sys/module/kvm_intel/parameters/tdx` → `Y`), boot the sealed image locally with real attestation:
+
+```bash
+# Fetch the latest qcow2 (or use a local `make build` output)
+gh release download -R easyenclave/easyenclave image-<sha> \
+    --pattern '*.qcow2'
+
+# Write a per-VM agent.env (KEY=VALUE per line)
+cat > /tmp/agent.env <<'EOF'
+EE_OWNER=devopsdefender
+EE_BOOT_WORKLOADS=[{"image":"docker.io/library/busybox","app_name":"smoke","cmd":["sh","-c","echo hello; sleep 3600"]}]
+EOF
+
+# Boot: builds an iso9660 config disk with /agent.env, copies the qcow2
+# and iso into /var/lib/libvirt/images/, launches via virt-install with
+# --launchSecurity type=tdx, and attaches the serial console.
+bash image/run-local.sh easyenclave-<sha>.qcow2 /tmp/agent.env
+
+# Tear down when done (Ctrl-] detaches from the serial first)
+bash image/run-local.sh --destroy
+```
+
+Host dependencies: `libvirt-clients`, `virtinst`, `qemu-system-x86`, `ovmf`, `genisoimage`. The user running this must be in the `libvirt` group.
+
+Networking is libvirt's default `virbr0` NAT bridge — the sealed VM's `dhclient` acquires a 192.168.122.x lease automatically. GCE metadata fetch silently skips (no metadata server locally), so per-VM config comes from `/agent.env` on the iso9660 secondary disk.
+
 ## Source
 
 ```

--- a/image/mkosi.conf
+++ b/image/mkosi.conf
@@ -30,6 +30,7 @@ Packages=
     ca-certificates
     uidmap
     libseccomp2
+    isc-dhcp-client
 
 # Only include kernel modules needed for TDX boot.
 KernelModulesInitrdInclude=

--- a/image/run-local.sh
+++ b/image/run-local.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# run-local.sh — boot the sealed easyenclave image locally on this
+# host via libvirt with real TDX launch security.
+#
+# Usage:
+#   bash image/run-local.sh <qcow2> <agent.env>
+#   bash image/run-local.sh --destroy
+#
+# Requires a TDX-capable host with:
+#   - kvm_intel.tdx=Y (check: /sys/module/kvm_intel/parameters/tdx)
+#   - libvirt + virt-install + qemu-system-x86 installed
+#   - /usr/share/OVMF/OVMF_CODE.fd (apt install ovmf)
+#   - genisoimage (apt install genisoimage)
+#   - user in the libvirt group
+#
+# What it does:
+#   1. Destroys any existing easyenclave-local domain (idempotent).
+#   2. Builds a tiny iso9660 config disk with /agent.env via
+#      genisoimage (no sudo, no mkfs, same pattern marketplace uses).
+#   3. Copies the qcow2 and config disk into /var/lib/libvirt/images/
+#      (sudo, because the dir is root-owned).
+#   4. Calls virt-install with --launchSecurity type=tdx — real TDX
+#      attestation, not mock. The sealed VM's configfs-tsm interface
+#      reports against the same MRTD/RTMR measurements it would on GCP.
+#   5. Attaches serial console via virsh console (Ctrl-] to exit).
+#
+# Lifecycle:
+#   - Per-invocation: destroys prior instance, creates fresh one
+#   - Destroy only:   ./run-local.sh --destroy
+#
+# TDX attestation is REAL on this host because kvm_intel has tdx=Y.
+# On a non-TDX host this script fails at virt-install with a clear
+# error (the --launchSecurity type=tdx flag is rejected).
+
+set -euo pipefail
+
+VM_NAME="easyenclave-local"
+IMAGES_DIR="/var/lib/libvirt/images"
+
+usage() {
+    cat <<EOF >&2
+Usage: run-local.sh <qcow2> <agent.env>
+       run-local.sh --destroy
+
+Arguments:
+  qcow2       Path to easyenclave qcow2 image (from GH release or local make build)
+  agent.env   KEY=VALUE file (one per line) — easyenclave reads this at PID 1 init
+              via the secondary config disk path in src/init.rs.
+
+Flags:
+  --destroy   Destroy the existing easyenclave-local domain and exit.
+EOF
+    exit 1
+}
+
+destroy_existing() {
+    if virsh dominfo "$VM_NAME" &>/dev/null; then
+        echo "stopping existing $VM_NAME..."
+        virsh destroy "$VM_NAME" 2>/dev/null || true
+        virsh undefine "$VM_NAME" --remove-all-storage 2>/dev/null || true
+    fi
+}
+
+if [[ "${1:-}" == "--destroy" ]]; then
+    destroy_existing
+    echo "done."
+    exit 0
+fi
+
+QCOW2="${1:?}"; ENV_FILE="${2:?}"
+[[ $# -eq 2 ]] || usage
+
+[ -f "$QCOW2" ]    || { echo "qcow2 not found: $QCOW2" >&2; exit 1; }
+[ -f "$ENV_FILE" ] || { echo "agent.env not found: $ENV_FILE" >&2; exit 1; }
+
+# ── Preflight ────────────────────────────────────────────────────────────
+TDX_FLAG=$(cat /sys/module/kvm_intel/parameters/tdx 2>/dev/null || echo "N")
+if [ "$TDX_FLAG" != "Y" ]; then
+    echo "warning: kvm_intel tdx=$TDX_FLAG — --launchSecurity type=tdx will fail" >&2
+    echo "         ensure the host boots with kvm_intel.tdx=1 kernel param" >&2
+fi
+
+for bin in virsh virt-install genisoimage; do
+    command -v "$bin" >/dev/null || {
+        echo "required tool not found: $bin" >&2
+        echo "try: sudo apt-get install libvirt-clients virtinst qemu-system-x86 genisoimage" >&2
+        exit 1
+    }
+done
+
+# ── Stop any prior instance ──────────────────────────────────────────────
+destroy_existing
+
+# ── Build the iso9660 config disk ────────────────────────────────────────
+# easyenclave's src/init.rs:76-92 probes /dev/vdb (and /dev/sdb) for a
+# secondary config disk in iso9660/ext4/vfat/ext2 and reads /agent.env
+# from its root. iso9660 via genisoimage is the simplest offline build:
+# no mkfs, no loop mount, no mtools — same tool marketplace uses to
+# ship cloud-init media on the same baremetal host.
+STAGING_DIR=$(mktemp -d)
+CONFIG_ISO=$(mktemp --suffix=.iso)
+trap 'rm -rf "$STAGING_DIR" "$CONFIG_ISO"' EXIT
+
+install -m 0644 "$ENV_FILE" "${STAGING_DIR}/agent.env"
+genisoimage -quiet -output "$CONFIG_ISO" -volid ee-config -joliet -rock "$STAGING_DIR"
+
+# ── Copy images into libvirt's dir (root-owned, needs sudo) ─────────────
+BOOT_DISK="${IMAGES_DIR}/${VM_NAME}.qcow2"
+CONFIG_DISK="${IMAGES_DIR}/${VM_NAME}-config.iso"
+sudo install -m 0644 "$QCOW2"      "$BOOT_DISK"
+sudo install -m 0644 "$CONFIG_ISO" "$CONFIG_DISK"
+
+# ── Launch with real TDX ─────────────────────────────────────────────────
+# q35 machine + UEFI firmware + launchSecurity type=tdx is the minimum
+# set for Intel TDX on libvirt. The default virbr0 NAT bridge gives
+# DHCP on 192.168.122.x so easyenclave's dhclient at init gets a lease
+# and can reach the outside world.
+echo "easyenclave: libvirt launch"
+echo "  vm:      $VM_NAME (TDX)"
+echo "  image:   $QCOW2 → $BOOT_DISK"
+echo "  config:  $ENV_FILE → /dev/vdb → /agent.env"
+echo
+
+virt-install \
+    --name "$VM_NAME" \
+    --ram 4096 \
+    --vcpus 2 \
+    --machine q35 \
+    --disk "path=${BOOT_DISK},format=qcow2,bus=virtio" \
+    --disk "path=${CONFIG_DISK},format=raw,bus=virtio" \
+    --network bridge=virbr0 \
+    --graphics none \
+    --console pty,target_type=serial \
+    --boot firmware=efi \
+    --launchSecurity type=tdx \
+    --import \
+    --noautoconsole
+
+echo
+echo "attached to $VM_NAME serial console (Ctrl-] to detach):"
+exec virsh console "$VM_NAME"

--- a/src/init.rs
+++ b/src/init.rs
@@ -73,8 +73,11 @@ pub fn maybe_init() {
     let config_mounted = {
         let mut mounted = false;
         std::thread::sleep(std::time::Duration::from_secs(1));
+        // iso9660 first because it's the simplest to build offline
+        // (genisoimage — no mkfs needed, no mtools). ext4/vfat/ext2
+        // remain as fallbacks for other tooling.
         for dev in ["/dev/vdb", "/dev/sdb"] {
-            for fstype in ["ext4", "vfat", "ext2"] {
+            for fstype in ["iso9660", "ext4", "vfat", "ext2"] {
                 if nix_mount_ro(dev, config_dir, fstype).is_ok() {
                     eprintln!("easyenclave: init: mounted config disk ({dev}, {fstype})");
                     mounted = true;
@@ -106,14 +109,9 @@ pub fn maybe_init() {
             .status();
     }
 
-    // GCE instance metadata: fetch the `ee-config` attribute and apply
-    // each key as an env var. This is the per-VM boot-config path for
-    // easyenclave VMs on GCP — gcloud passes it via
-    //   --metadata-from-file=ee-config=<path to JSON>
-    // Non-GCE hosts fail silently (no metadata server reachable).
-    fetch_gce_metadata_config();
-
-    // Set up networking
+    // Set up networking FIRST — the GCE metadata fetch below depends
+    // on having an IP and a route to 169.254.169.254, both of which
+    // come from the DHCP lease (option 121 classless static routes).
     let ip_bin = "/sbin/ip";
     let _ = std::process::Command::new(ip_bin)
         .args(["link", "set", "lo", "up"])
@@ -135,23 +133,58 @@ pub fn maybe_init() {
             .status();
 
         if let Ok(ee_ip) = std::env::var("EE_IP") {
-            eprintln!("easyenclave: init: setting {iface} ip={ee_ip}");
+            // Static IP path: EE_IP set via cmdline or secondary disk.
+            // Used for locked-down deployments that don't want DHCP.
+            eprintln!("easyenclave: init: setting {iface} ip={ee_ip} (static)");
             let _ = std::process::Command::new(ip_bin)
                 .args(["addr", "add", &ee_ip, "dev", iface])
                 .status();
-        }
-        if let Ok(gw) = std::env::var("EE_GATEWAY") {
-            eprintln!("easyenclave: init: default route via {gw}");
-            let _ = std::process::Command::new(ip_bin)
-                .args(["route", "add", "default", "via", &gw, "dev", iface])
-                .status();
+            if let Ok(gw) = std::env::var("EE_GATEWAY") {
+                eprintln!("easyenclave: init: default route via {gw}");
+                let _ = std::process::Command::new(ip_bin)
+                    .args(["route", "add", "default", "via", &gw, "dev", iface])
+                    .status();
+            }
+        } else {
+            // DHCP path: fetch IP + routes + DNS + GCE metadata route
+            // from the DHCP server. dhclient -1 runs once, installs
+            // the lease (incl. classless static routes via option 121
+            // on GCE), and exits (non-daemon mode). Time out after 30s
+            // so we don't block boot forever if there's no DHCP server.
+            eprintln!("easyenclave: init: running dhclient on {iface}");
+            match std::process::Command::new("/sbin/dhclient")
+                .args(["-1", "-v", "-timeout", "30", iface])
+                .status()
+            {
+                Ok(s) if s.success() => {
+                    eprintln!("easyenclave: init: dhcp lease acquired");
+                }
+                Ok(s) => {
+                    eprintln!("easyenclave: init: dhclient exited with {s}");
+                }
+                Err(e) => {
+                    eprintln!("easyenclave: init: dhclient failed: {e}");
+                }
+            }
         }
     }
     if let Ok(dns) = std::env::var("EE_DNS") {
-        eprintln!("easyenclave: init: dns={dns}");
+        eprintln!("easyenclave: init: dns={dns} (static override)");
         let _ = std::fs::write("/tmp/resolv.conf", format!("nameserver {dns}\n"));
         let _ = nix_mount_flags("/tmp/resolv.conf", "/etc/resolv.conf", "", libc::MS_BIND);
     }
+
+    // GCE instance metadata: fetch the `ee-config` attribute and apply
+    // each key as an env var. This is the per-VM boot-config path for
+    // easyenclave VMs on GCP — gcloud passes it via
+    //   --metadata-from-file=ee-config=<path to JSON>
+    // Non-GCE hosts (local QEMU, non-cloud) fail silently here and get
+    // their config from the secondary disk `/agent.env` or from the
+    // kernel cmdline `ee.*` params.
+    //
+    // Runs AFTER networking is configured — dhclient installs the
+    // classless static route to 169.254.169.254 on GCE.
+    fetch_gce_metadata_config();
 
     // Start zombie reaper thread (PID 1 must reap children)
     std::thread::spawn(|| loop {


### PR DESCRIPTION
## Summary

Two interlocking fixes. Both required before dd staging can boot real container workloads through easyenclave, and to enable a local TDX dev loop on machines that have the hardware.

## Part A: DHCP at init

**Root cause of the dd staging stall**: easyenclave reached "listening on socket" but never deployed any workloads. Serial log had zero `gce-meta` lines.

1. `src/init.rs:114` called `fetch_gce_metadata_config()` BEFORE the networking block at :116.
2. Even after `ip link set <iface> up`, there was no IP address assigned and no route to `169.254.169.254`. GCE's metadata server lives on the link-local range; DHCP option 121 (classless static routes) is how the metadata route gets installed by a running DHCP client.
3. easyenclave had no DHCP client. The route never existed. `fetch_gce_metadata_config` got a connection error from ureq and silently returned via the `Err(_) => return` arm.

**Fix:**

- \`image/mkosi.conf\`: add \`isc-dhcp-client\` to Packages.
- \`src/init.rs\`: reorder operations. Networking FIRST. If \`EE_IP\` is set, use static config (locked-down deployments). Otherwise run \`dhclient -1 -timeout 30 <iface>\`, blocking single-shot — acquires the lease, installs IP + routes + DNS + classless-static-routes, then exits. THEN call \`fetch_gce_metadata_config()\`.

After this, on GCE the metadata reaches the VM, \`EE_BOOT_WORKLOADS\` gets applied, libcontainer pulls the ghcr images, and workloads start.

## Part B: local TDX dev flow via libvirt

**New \`image/run-local.sh\`** — boots the sealed image locally with **real TDX attestation** (no mock). Modeled after \`marketplace/scripts/deploy-vm.sh\` — libvirt \`virt-install\` with \`--launchSecurity type=tdx\`, \`--machine q35\`, \`--boot firmware=efi\`.

Config disk: iso9660 built with \`genisoimage\` (the same tool marketplace already uses). Contains \`/agent.env\` at the root. easyenclave's existing secondary-disk probe in \`init.rs:70-92\` already mounted ext4/vfat/ext2 — added \`iso9660\` to the list so the genisoimage-built disk is recognized.

Usage:

\`\`\`bash
bash image/run-local.sh <qcow2> <agent.env>     # boot
bash image/run-local.sh --destroy                # tear down
\`\`\`

The script is idempotent: destroys any prior \`easyenclave-local\` domain, installs the qcow2 + iso into \`/var/lib/libvirt/images/\`, launches via \`virt-install\`, attaches serial console. Networking uses the default \`virbr0\` NAT bridge so the in-guest \`dhclient\` acquires a 192.168.122.x lease automatically. On a local host there's no GCE metadata server, so \`fetch_gce_metadata_config\` silently skips and config comes from \`/agent.env\` on the iso secondary disk.

**Host deps** (this host already has all of them): \`libvirt-clients\`, \`virtinst\`, \`qemu-system-x86\`, \`ovmf\`, \`genisoimage\`.

**README** updated with a "Run locally in TDX (libvirt)" section.

## Test plan

- [x] Local \`cargo build --release -Dwarnings\` clean
- [x] Local \`cargo clippy --all-targets -- -Dwarnings\` clean
- [x] Local \`cargo fmt --check\` clean
- [x] \`bash -n image/run-local.sh\` clean
- [ ] PR CI: \`ci.yml\` (lint-test) + \`image.yml\` (build + smoke-test) green
- [ ] Post-merge: new \`easyenclave-<sha>\` lands, smoke-test boots a real TDX VM through DHCP → gce-meta → listening
- [ ] Local: \`bash image/run-local.sh <qcow2> /tmp/agent.env\` on this host → sealed VM boots with real TDX attestation, dhclient lease, config disk mounted, /agent.env env vars applied, boot workload starts
- [ ] dd staging: bump \`gcp-deploy.sh\` pin to the new easyenclave-\<sha\>, re-run staging-deploy → for the first time, container workloads actually run end-to-end through libcontainer

## Related

- easyenclave#45 (GCE metadata reader — had the init-order bug this PR fixes)
- easyenclave#46 (libcontainer refactor — turned this from "broken silently" to "broken loudly" via kernel panic)
- easyenclave#47 (libseccomp.so.2 in rootfs — part of the same "rootfs needs deps that libcontainer wants" thread)
- marketplace scripts/deploy-vm.sh (the libvirt + TDX launch pattern this borrows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)