### PR TITLE
fix(ci): build UKI against linux-image-generic, not azure kernel

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -67,11 +67,32 @@ jobs:
             dosfstools \
             qemu-utils \
             libseccomp-dev \
-            zstd
+            zstd \
+            linux-image-generic
           # libseccomp-dev is needed to link libcontainer (youki) —
           # easyenclave's Rust-native container runtime depends on it.
           # zstd is used by mkinitrd.sh to decompress kernel modules so
           # busybox's insmod can load them (see mkinitrd.sh comment).
+          # linux-image-generic: GitHub Actions runners boot an Azure-
+          # flavored kernel (e.g. 6.17.0-1010-azure) that doesn't ship
+          # nvme, tdx-guest, or tsm_report as modules. The generic
+          # Ubuntu kernel has them. We install it here purely to pull
+          # its module tree + vmlinuz into /lib/modules + /boot so
+          # mkinitrd.sh can resolve deps and the UKI can bundle the
+          # right kernel. The runner itself keeps booting azure — we
+          # just pass KVER explicitly to the build step.
+
+      - name: Resolve target kernel version
+        id: kver
+        run: |
+          # Prefer the latest generic kernel (installed above). Falls
+          # back to uname -r so local `make build` on a generic-kernel
+          # host still works without manual KVER plumbing.
+          KVER=$(ls -1 /boot/vmlinuz-*-generic 2>/dev/null \
+            | sed 's|/boot/vmlinuz-||' | sort -V | tail -1)
+          [ -z "$KVER" ] && KVER=$(uname -r)
+          echo "Using KVER=$KVER (runner uname -r=$(uname -r))"
+          echo "kver=$KVER" >> "$GITHUB_OUTPUT"
 
       # mkosi is NOT published on PyPI — it ships only from systemd/mkosi
       # on GitHub. Ubuntu's apt mkosi is too old for Format=directory.
@@ -104,7 +125,9 @@ jobs:
         run: cargo build --release
 
       - name: Build VM image
-        run: cd image && make build
+        env:
+          KVER: ${{ steps.kver.outputs.kver }}
+        run: cd image && make build KVER="$KVER"
 
       - name: Compute measurements and rename artifacts
         id: meta


### PR DESCRIPTION
## Summary

Root cause of why #52's Zstd fix didn't unblock the smoke-test: **the CI build was packing modules for the wrong kernel all along**.

GitHub Actions runners are Azure VMs. \`uname -r\` reports an azure-flavored kernel (\`6.17.0-1010-azure\`). The Makefile does \`KVER ?= \$(shell uname -r)\` and \`cp /boot/vmlinuz-\$(KVER)\`, so we were baking the **runner's Azure kernel** straight into the UKI.

The Azure kernel is stripped: it doesn't ship \`nvme\`, \`tdx-guest\`, or \`tsm_report\` as modules (either compiled in or absent — Azure doesn't run guests as TDX, so no attestation drivers). \`modprobe --show-depends nvme|tdx-guest|tsm-report\` returns nothing, \`mkinitrd.sh\` silently copies nothing, and the initrd ships with just dm-verity + dm-bufio.

## Ground truth

I pulled the released UKI for \`21a1249cad72\`, extracted its initrd with \`objcopy --dump-section .initrd=\`, and looked inside:

\`\`\`
$ cat lib/modules/*/modules.dep
kernel/drivers/md/dm-verity.ko: kernel/drivers/md/dm-bufio.ko
kernel/drivers/md/dm-bufio.ko:

$ find lib/modules -name '*.ko'
lib/modules/6.17.0-1010-azure/kernel/drivers/md/dm-bufio.ko
lib/modules/6.17.0-1010-azure/kernel/drivers/md/dm-verity.ko
\`\`\`

Two modules. Azure kernel. No nvme. No tdx-guest. Our fast-fail on \`modprobe tdx_guest\` correctly tripped.

## Fix

Install \`linux-image-generic\` on the runner before the build step, and resolve its KVER via \`ls /boot/vmlinuz-*-generic | sort -V | tail -1\`. Pass it to \`make build KVER=<kver>\`. The Makefile already supported \`KVER ?=\` override, so no Makefile change.

The runner itself keeps booting the Azure kernel — we just redirect the image build to the generic kernel's \`/lib/modules/<kver>-generic/\` tree and \`/boot/vmlinuz-<kver>-generic\`.

## Local verification

\`sudo make build\` on my generic-kernel dev box produces an initrd with all 9 expected .ko files (dm-verity + dm-bufio; nvme chain hkdf + nvme-auth + nvme-keyring + nvme-core + nvme; tdx-guest + tsm_report) and a modules.dep that references them. Direct test of \`busybox modprobe -D\` against the extracted tree:

\`\`\`
$ sudo chroot . /bin/busybox modprobe -D tdx_guest
insmod /lib/modules/7.0.0-13-generic/kernel/drivers/virt/coco/guest/tsm_report.ko
insmod /lib/modules/7.0.0-13-generic/kernel/drivers/virt/coco/tdx-guest/tdx-guest.ko
\`\`\`

\`tdx_guest\` (underscore) → \`tdx-guest.ko\` (hyphen) resolution works in busybox. Each module loads.

## Test plan

- [ ] CI image build succeeds
- [ ] Post-merge smoke-test passes (first green smoke-test since #47)
- [ ] Rerun dd staging-deploy — with #78 merged, serial stream should now show all 4 modprobes succeeding, DHCP lease, GCE metadata fetch, EE_BOOT_WORKLOADS applied, libcontainer pulls, /health 200

## Risk

- \`linux-image-generic\` is a meta-package. If the Ubuntu archive rotates and installs a kernel without tdx-guest as a module (unlikely — 6.8+ HWE and newer have it), we'd regress. Mitigation if that happens: pin to a specific \`linux-image-6.X-generic\` version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)