### PR TITLE
fix(initrd): modprobe gve + virtio_net so easyenclave sees the NIC

### DIFF
--- a/image/mkinitrd.sh
+++ b/image/mkinitrd.sh
@@ -74,7 +74,7 @@ copy_mod() {
     esac
 }
 
-for top in dm-verity nvme tdx-guest tsm-report; do
+for top in dm-verity nvme tdx-guest tsm-report gve virtio_net; do
     deps=$(modprobe --show-depends --set-version "$KVER" "$top" 2>&1 || true)
     if ! echo "$deps" | grep -q '^insmod'; then
         echo "  $top: not available as a module on $KVER (built-in or absent)"
@@ -148,9 +148,18 @@ done
 # driver is still in the kernel. If it's genuinely missing, easyenclave's
 # attestation backend detection will fail later with a clearer error.
 modprobe dm-verity 2>/dev/null || echo "note: dm-verity not loaded (may be built-in)"
-modprobe nvme 2>/dev/null     || echo "note: nvme not loaded (may be built-in or N/A)"
+modprobe nvme 2>/dev/null      || echo "note: nvme not loaded (may be built-in or N/A)"
 modprobe tdx_guest 2>/dev/null || echo "note: tdx_guest not loaded (may be built-in)"
 modprobe tsm_report 2>/dev/null || echo "note: tsm_report not loaded (may be built-in)"
+# Network drivers — needed BEFORE switch_root so /sys/class/net has a
+# non-lo interface by the time easyenclave's init.rs reads it to decide
+# which interface to DHCP. Without this, easyenclave sees only "lo",
+# skips the entire `if let Some(iface)` block, never runs udhcpc, never
+# fetches GCE metadata, never deploys workloads — the VM silently
+# reaches "listening on" with no network. GCP c3 machines use gVNIC
+# (gve driver); other types use virtio-net.
+modprobe gve 2>/dev/null       || echo "note: gve not loaded (not a c3/gvnic host?)"
+modprobe virtio_net 2>/dev/null || echo "note: virtio_net not loaded (not a virtio host?)"
 
 # Resolve LABEL=/UUID= to a device path. The cmdline uses
 # `root=LABEL=root` so one UKI boots on both GCP (nvme0n1p2) and


### PR DESCRIPTION
## Summary

dd staging-deploy on \`easyenclave-4d3aaa6648b5\` got **further than ever** — VM booted, initrd loaded dm-verity/nvme/tdx-guest, root mounted, easyenclave reached \`listening on /var/lib/easyenclave/agent.sock\` AND \`attestation backend: tdx\` — but **no workloads deployed**. Serial log jumped silently from mount setup straight to "init complete":

\`\`\`
easyenclave: init: mounted /var/lib/easyenclave (tmpfs, writable)
[/dev/vdb: Can't lookup blockdev ×4]
easyenclave: init complete
easyenclave: attestation backend: tdx
easyenclave: listening on /var/lib/easyenclave/agent.sock
\`\`\`

Missing: no \`running udhcpc\`, no \`dhcp lease acquired\`, no \`gce-meta env\`, no workload deploys.

## Root cause

\`src/init.rs\`'s networking block is gated on finding a non-lo interface in \`/sys/class/net\`:

\`\`\`rust
let iface = std::fs::read_dir("/sys/class/net")
    .ok()
    .and_then(|e| e.flatten().map(...).find(|n| n != "lo"));
if let Some(ref iface) = iface {   // silent skip if None
    ...run udhcpc, fetch metadata, etc...
}
\`\`\`

On GCP c3 TDX instances, the NIC is Google gVNIC — PCI ID \`1ae0:0042\`, driver \`gve\`. The mkinitrd.sh module loop only copied \`dm-verity nvme tdx-guest tsm-report\` — never \`gve\` — so the driver never loaded, \`/sys/class/net\` had only \`lo\`, \`.find(|n| n != "lo")\` returned None, and the entire networking + metadata fetch was silently skipped.

Kernel log confirms no gve binding on PCI \`00:03.0\`:

\`\`\`
[    1.886690] pci 0000:00:03.0: [1ae0:0042] type 00 class 0x020000
[no driver binding — gve never loaded]
\`\`\`

## Fix

Add \`gve virtio_net\` to both the build-time mkinitrd.sh module list and the runtime initrd init heredoc's modprobe calls:

- **gve**: GCP c3 (TDX) and similar instance types
- **virtio_net**: GCP n2/n1/e2 and non-GCP qemu/kvm hosts

Both use the existing tolerant fall-through that #54 added — missing modules log a note and continue, built-in modules (virtio_net is \`=y\` on 7.0.0+ kernels) no-op gracefully.

## Local verification

\`\`\`
$ sudo bash mkinitrd.sh /tmp/t.initrd $(uname -r)
  gve: 1 files processed
  virtio_net: not available as a module on 7.0.0-13-generic
=== initrd module tree ===
kernel/drivers/net/ethernet/google/gve/gve.ko
[+ the other 9 modules]
Initrd built: /tmp/t.initrd (6.8M)
\`\`\`

## Test plan

- [ ] Image build + smoke-test pass (should — smoke-test already passes today, this just adds one more module)
- [ ] After merge, rerun dd staging-deploy → Action log serial stream shows:
  - \`gve ...:00:03.0 eth0: Device attached\` or similar (kernel gve binding)
  - \`easyenclave: init: running udhcpc on enp0s3\`
  - \`easyenclave: init: dhcp lease acquired\`
  - \`easyenclave: init: gce-meta env ...\` for each ee-config key
  - Workload deploy lines, libcontainer pulls from ghcr, cloudflared tunnel up
  - \`Agent healthy at https://app-staging.devopsdefender.com\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)