### PR TITLE
fix(init): pass -s to udhcpc so the hook script runs

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -153,12 +153,26 @@ pub fn maybe_init() {
             // DHCP path: fetch IP + routes + DNS + classless static
             // routes from the DHCP server. busybox udhcpc in one-shot
             // mode (-n: exit if no lease, -q: quit after obtaining
-            // lease, -t 10: retry 10× = ~30s timeout). The default
-            // hook script at /usr/share/udhcpc/default.script is
-            // provided by mkosi.extra and applies the IP/routes/DNS.
+            // lease, -t 10: retry 10× = ~30s timeout, -s: hook script
+            // path). busybox udhcpc's compiled-in default is
+            // /etc/udhcpc/default.script, but we ship our hook at
+            // /usr/share/udhcpc/default.script (via mkosi.extra), so
+            // -s is required. The hook applies IP + gateway + DNS +
+            // RFC 3442 classless static routes (option 121) from the
+            // lease — the classless-route handling is what makes GCE's
+            // metadata server at 169.254.169.254 reachable.
             eprintln!("easyenclave: init: running udhcpc on {iface}");
             match std::process::Command::new("udhcpc")
-                .args(["-i", iface, "-q", "-n", "-t", "10"])
+                .args([
+                    "-i",
+                    iface,
+                    "-q",
+                    "-n",
+                    "-t",
+                    "10",
+                    "-s",
+                    "/usr/share/udhcpc/default.script",
+                ])
                 .status()
             {
                 Ok(s) if s.success() => {


### PR DESCRIPTION
## Summary

dd staging-deploy on \`easyenclave-3ca3e23196\` got ALL the way to \`listening on\` with a DHCP lease — but GCE metadata fetch still failed silently. The metadata server at 169.254.169.254 was unreachable because the classless static route (DHCP option 121) was never installed.

## Root cause

busybox udhcpc's compiled-in default hook-script path is \`/etc/udhcpc/default.script\`. Our hook lives at \`/usr/share/udhcpc/default.script\` (shipped via \`image/mkosi.extra/\`). Without the \`-s\` flag in the udhcpc invocation, our hook never ran. udhcpc assigned the IP internally (the lease message appeared in serial) but routes, DNS, and RFC 3442 classless static routes from the lease were silently dropped.

Serial log confirmed: \`udhcpc: lease of 10.128.15.192 obtained\` but zero route/DNS application. And no \`gce-meta env\` lines afterward.

## Fix

One arg: \`-s /usr/share/udhcpc/default.script\`.

## Test plan

- [ ] CI lint-test + image build green
- [ ] Smoke-test passes (already was passing — this is a metadata-fetch fix, not a boot fix)
- [ ] After merge, dd staging-deploy serial stream should now show:
  - \`udhcpc: lease ... obtained\` (already worked)
  - Route application from the hook script
  - \`easyenclave: init: gce-meta env EE_BOOT_WORKLOADS=<redacted>\`
  - Workload deploy lines (libcontainer pulling dd-register + dd-web from ghcr)
  - Cloudflared tunnel startup
  - \`Agent healthy at https://app-staging.devopsdefender.com\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)