### PR TITLE
debug(init): log DHCP variables in udhcpc hook

### DIFF
--- a/image/mkosi.extra/usr/share/udhcpc/default.script
+++ b/image/mkosi.extra/usr/share/udhcpc/default.script
@@ -20,6 +20,8 @@ case "$1" in
     ;;
 
   bound|renew)
+    echo "udhcpc-hook: $1 ip=$ip mask=$mask router=$router dns=$dns"
+    echo "udhcpc-hook: staticroutes='$staticroutes' msstaticroutes='$msstaticroutes'"
     $IP addr flush dev "$interface" 2>/dev/null || true
     $IP addr add "$ip/$mask" dev "$interface"
     $IP link set "$interface" up


### PR DESCRIPTION
Diagnostic — adds two echo lines to the udhcpc hook's bound/renew handler so the serial log shows what DHCP variables busybox passes to the hook. We need to see whether \`\$staticroutes\` is populated or empty despite \`-O staticroutes\` in #57.

Will remove the debug lines once we've confirmed the metadata route is working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)