### PR TITLE
debug(init): dump routing table + log metadata fetch error

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -182,6 +182,14 @@ pub fn maybe_init() {
             {
                 Ok(s) if s.success() => {
                     eprintln!("easyenclave: init: dhcp lease acquired");
+                    // Diagnostic: dump routing table so serial shows
+                    // whether the default route + on-link gateway landed.
+                    let _ = std::process::Command::new("ip")
+                        .args(["route", "show"])
+                        .status();
+                    let _ = std::process::Command::new("ip")
+                        .args(["addr", "show", "dev", iface])
+                        .status();
                 }
                 Ok(s) => {
                     eprintln!("easyenclave: init: udhcpc exited with {s}");
@@ -250,9 +258,11 @@ fn fetch_gce_metadata_config() {
                 return;
             }
         },
-        Err(_) => {
-            // Not on GCE (connection refused / timeout), or attribute
-            // not set (404). Nothing to do.
+        Err(e) => {
+            // Log the actual error so serial output shows WHY the
+            // metadata fetch failed (timeout? network unreachable?
+            // connection refused? DNS?). Previously this was silent.
+            eprintln!("easyenclave: init: gce-meta fetch failed: {e}");
             return;
         }
     };


### PR DESCRIPTION
Diagnostic — two additions to serial output:

1. After DHCP lease: \`ip route show\` + \`ip addr show dev eth0\` so we can see whether the default route and on-link gateway from option 121 classless static routes actually landed in the kernel routing table.

2. Metadata fetch: log the actual ureq error (\`timeout\`, \`network unreachable\`, \`connection refused\`, etc.) instead of silently returning. Previous behavior swallowed all errors with \`Err(_) => return\`.

Context: #58 confirmed \`\$staticroutes\` IS populated (\`10.128.0.1/32 0.0.0.0 0.0.0.0/0 10.128.0.1\`), so the hook should be installing the routes. But we can't see whether they actually landed, and the metadata fetch fails silently. These two diagnostics close the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)