### PR TITLE
fix(init): handle RFC 3442 on-link gateway (0.0.0.0) in udhcpc hook

### DIFF
--- a/image/mkosi.extra/usr/share/udhcpc/default.script
+++ b/image/mkosi.extra/usr/share/udhcpc/default.script
@@ -33,13 +33,26 @@ case "$1" in
       done
     fi
 
-    # Classless static routes (DHCP option 121). GCE uses this to
-    # install the 169.254.169.254/32 metadata route.
-    # Format: "dest1/prefix1 gateway1 dest2/prefix2 gateway2 ..."
+    # Classless static routes (DHCP option 121). GCE sends two:
+    #   10.128.0.1/32 0.0.0.0   — gateway reachable on-link
+    #   0.0.0.0/0 10.128.0.1    — default route via gateway
+    # Format: "dest/prefix gateway dest/prefix gateway ..."
+    #
+    # Gateway 0.0.0.0 means "on-link" per RFC 3442. MUST use
+    # `ip route add <dest> dev <iface>`, NOT `via 0.0.0.0`.
+    # The `via 0.0.0.0` form creates a route without scope link,
+    # and the kernel then rejects it as a valid next-hop for other
+    # routes (RTNETLINK: Network is unreachable). This was the bug
+    # that prevented the default route from landing on GCE.
     if [ -n "$staticroutes" ]; then
       set -- $staticroutes
       while [ "$#" -ge 2 ]; do
-        $IP route add "$1" via "$2" dev "$interface" 2>/dev/null || true
+        if [ "$2" = "0.0.0.0" ]; then
+          # On-link: gateway 0.0.0.0 means directly connected
+          $IP route add "$1" dev "$interface" 2>/dev/null || true
+        else
+          $IP route add "$1" via "$2" dev "$interface" 2>/dev/null || true
+        fi
         shift 2
       done
     fi


### PR DESCRIPTION
## Summary

\`ip route add 10.128.0.1/32 via 0.0.0.0 dev eth0\` creates a route WITHOUT \`scope link\`. The kernel then rejects \`10.128.0.1\` as a valid next-hop: \`RTNETLINK answers: Network is unreachable\`. The default route silently fails (\`|| true\`), leaving the VM with no default route and 169.254.169.254 unreachable.

Reproduced in a netns with busybox 1.36.1 (exact rootfs binary):
\`\`\`
$ bb ip route add 10.128.0.1/32 via 0.0.0.0 dev dummy0   # exit=0, but wrong scope
$ bb ip route add 0.0.0.0/0 via 10.128.0.1 dev dummy0
ip: RTNETLINK answers: Network is unreachable                # exit=2
\`\`\`

Fix: per RFC 3442, gateway \`0.0.0.0\` = on-link. Use \`ip route add <dest> dev <iface>\` (no \`via\`):
\`\`\`
$ bb ip route add 10.128.0.1/32 dev dummy0                  # scope link ✓
$ bb ip route add 0.0.0.0/0 via 10.128.0.1 dev dummy0       # exit=0 ✓
$ bb ip route show
default via 10.128.0.1 dev dummy0
10.128.0.1 dev dummy0 scope link
\`\`\`

## The layer cake is now at 9 layers (#50–#60)

| # | Layer |
|---|---|
| #50 | No DHCP, metadata fetch before networking |
| #52 | Zstd modules not loadable |
| #53 | Azure kernel bundled |
| #54 | set -e + missing modules killed build |
| #55 | No gve → no NIC |
| #56 | Wrong hook-script path |
| #57 | Option 121 not requested |
| #58 | Debug: log DHCP variables |
| #59 | Debug: log routes + metadata error |
| **#60** | **On-link gateway via 0.0.0.0 → wrong scope → no default route** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)