### PR TITLE
fix(init): bind-mount DHCP resolv.conf so ghcr.io resolves

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -200,10 +200,23 @@ pub fn maybe_init() {
             }
         }
     }
+    // DNS: the udhcpc hook writes the DHCP-provided nameservers to
+    // /tmp/resolv.conf.udhcpc (because the rootfs is read-only and
+    // direct writes to /etc/resolv.conf fail). Bind-mount it over
+    // /etc/resolv.conf so ureq/libcontainer/curl can resolve hostnames
+    // like ghcr.io. EE_DNS overrides the DHCP-provided DNS if set.
     if let Ok(dns) = std::env::var("EE_DNS") {
         eprintln!("easyenclave: init: dns={dns} (static override)");
         let _ = std::fs::write("/tmp/resolv.conf", format!("nameserver {dns}\n"));
         let _ = nix_mount_flags("/tmp/resolv.conf", "/etc/resolv.conf", "", libc::MS_BIND);
+    } else if std::path::Path::new("/tmp/resolv.conf.udhcpc").exists() {
+        eprintln!("easyenclave: init: dns from dhcp lease");
+        let _ = nix_mount_flags(
+            "/tmp/resolv.conf.udhcpc",
+            "/etc/resolv.conf",
+            "",
+            libc::MS_BIND,
+        );
     }
 
     // GCE instance metadata: fetch the `ee-config` attribute and apply


### PR DESCRIPTION
## Summary

Layer 11: libcontainer can't pull from ghcr.io because DNS isn't configured. The udhcpc hook writes nameservers to \`/tmp/resolv.conf.udhcpc\` but the rootfs is read-only, so nothing lands in \`/etc/resolv.conf\`. Metadata fetch worked (raw IP 169.254.169.254), but ghcr.io needs DNS.

Fix: bind-mount \`/tmp/resolv.conf.udhcpc\` over \`/etc/resolv.conf\` after DHCP succeeds. Same pattern as the existing \`EE_DNS\` override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)