### PR TITLE
feat(ci): checklist-based smoke test for the full boot chain

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -416,12 +416,38 @@ jobs:
             echo "label=${SHA12}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Boot TDX VM from new image and verify
+      - name: Boot TDX VM and validate boot chain
         env:
           GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
           GCP_NAME: ${{ steps.target.outputs.gcp_name }}
           LABEL: ${{ steps.target.outputs.label }}
         run: |
+          # ── Boot chain checklist ──────────────────────────────────────
+          # Each marker validates a stage of the sealed VM boot. Required
+          # markers must all appear for the smoke test to pass. Optional
+          # markers are informational (e.g. gce-meta requires ee-config
+          # metadata, which the smoke VM doesn't have).
+          #
+          # This checklist exists because we spent PRs #50-#61 debugging
+          # 11 layers of boot failures that the old "grep for listening"
+          # test couldn't catch: missing network driver, DHCP failure,
+          # wrong route scope, DNS misconfiguration, etc.
+
+          # name:pattern:required (1=yes, 0=optional)
+          CHECKS=(
+            "kernel_boot:Run /init as init process:1"
+            "root_resolved:Resolved root to /dev/:1"
+            "easyenclave_pid1:easyenclave: running as PID 1:1"
+            "tmpfs_mounted:mounted /var/lib/easyenclave:1"
+            "tdx_attestation:attestation backend: tdx:1"
+            "network_up:Device link is up:1"
+            "dhcp_lease:lease of .* obtained:1"
+            "default_route:default via .* dev:1"
+            "dns_configured:dns from dhcp lease:1"
+            "gce_metadata:gce-meta env:0"
+            "listening:easyenclave: listening on:1"
+          )
+
           VM_NAME="ee-smoke-$(date +%s)"
           gcloud compute instances create "$VM_NAME" \
             --project="$GCP_PROJECT" \
@@ -438,29 +464,90 @@ jobs:
               --project="$GCP_PROJECT" --zone=us-central1-c --quiet || true
           }
 
+          # Track which checks have passed
+          declare -A PASSED
+          LAST_LINES=0
+          ALL_REQUIRED_DONE=false
+
           for i in $(seq 1 30); do
             out=$(gcloud compute instances get-serial-port-output "$VM_NAME" \
               --project="$GCP_PROJECT" --zone=us-central1-c 2>/dev/null || true)
 
-            if echo "$out" | grep -q "easyenclave: listening on"; then
-              echo "✓ image ${LABEL} booted and easyenclave is listening"
-              cleanup
-              exit 0
+            # Stream new serial lines
+            TOTAL_LINES=$(echo "$out" | wc -l)
+            if [ "$TOTAL_LINES" -gt "$LAST_LINES" ]; then
+              echo "$out" | tail -n +$((LAST_LINES + 1)) | sed 's/^/[serial] /'
+              LAST_LINES=$TOTAL_LINES
             fi
 
-            if echo "$out" | grep -qE "FATAL|Kernel panic|switch_root: can"; then
-              echo "::error::boot failed for image ${LABEL}"
-              echo "$out" | tail -60
-              cleanup
-              exit 1
+            # Fast-fail on fatal patterns
+            if echo "$out" | grep -qE "FATAL|Kernel panic|switch_root: can|Invalid ELF header"; then
+              echo ""
+              echo "::error::boot failed for image ${LABEL} — fatal pattern in serial"
+              break
             fi
 
-            echo "  waiting for listening marker... (${i}/30)"
+            # Check each marker
+            for check in "${CHECKS[@]}"; do
+              IFS=: read -r name pattern required <<< "$check"
+              [ -n "${PASSED[$name]:-}" ] && continue
+              if echo "$out" | grep -qE "$pattern"; then
+                PASSED[$name]=1
+                echo "  ✓ $name"
+              fi
+            done
+
+            # Are all required checks done?
+            ALL_REQUIRED_DONE=true
+            for check in "${CHECKS[@]}"; do
+              IFS=: read -r name pattern required <<< "$check"
+              [ "$required" = "0" ] && continue
+              [ -z "${PASSED[$name]:-}" ] && ALL_REQUIRED_DONE=false && break
+            done
+
+            if $ALL_REQUIRED_DONE; then
+              break
+            fi
+
+            echo "  waiting... (${i}/30)"
             sleep 10
           done
 
-          echo "::error::image ${LABEL} did not become ready within 5 min"
-          gcloud compute instances get-serial-port-output "$VM_NAME" \
-            --project="$GCP_PROJECT" --zone=us-central1-c | tail -60 || true
-          cleanup
-          exit 1
+          # ── Print checklist summary ─────────────────────────────────
+          echo ""
+          echo "=== easyenclave smoke test results (${LABEL}) ==="
+          REQUIRED_PASS=0
+          REQUIRED_TOTAL=0
+          OPTIONAL_PASS=0
+          for check in "${CHECKS[@]}"; do
+            IFS=: read -r name pattern required <<< "$check"
+            if [ -n "${PASSED[$name]:-}" ]; then
+              echo "  ✓ $name"
+              [ "$required" = "1" ] && REQUIRED_PASS=$((REQUIRED_PASS + 1))
+              [ "$required" = "0" ] && OPTIONAL_PASS=$((OPTIONAL_PASS + 1))
+            else
+              if [ "$required" = "1" ]; then
+                echo "  ✗ $name  (REQUIRED)"
+              else
+                echo "  - $name  (optional, not expected on smoke VM)"
+              fi
+            fi
+            [ "$required" = "1" ] && REQUIRED_TOTAL=$((REQUIRED_TOTAL + 1))
+          done
+          echo ""
+          echo "${REQUIRED_PASS}/${REQUIRED_TOTAL} required checks passed"
+          echo "==="
+
+          if $ALL_REQUIRED_DONE; then
+            echo ""
+            echo "✓ image ${LABEL} passed all required smoke checks"
+            cleanup
+            exit 0
+          else
+            echo ""
+            echo "::error::image ${LABEL} failed smoke test (${REQUIRED_PASS}/${REQUIRED_TOTAL} required)"
+            echo "--- final serial tail ---"
+            echo "$out" | tail -80
+            cleanup
+            exit 1
+          fi

--- a/image/mkosi.extra/usr/share/udhcpc/default.script
+++ b/image/mkosi.extra/usr/share/udhcpc/default.script
@@ -20,8 +20,6 @@ case "$1" in
     ;;
 
   bound|renew)
-    echo "udhcpc-hook: $1 ip=$ip mask=$mask router=$router dns=$dns"
-    echo "udhcpc-hook: staticroutes='$staticroutes' msstaticroutes='$msstaticroutes'"
     $IP addr flush dev "$interface" 2>/dev/null || true
     $IP addr add "$ip/$mask" dev "$interface"
     $IP link set "$interface" up

--- a/src/init.rs
+++ b/src/init.rs
@@ -182,14 +182,6 @@ pub fn maybe_init() {
             {
                 Ok(s) if s.success() => {
                     eprintln!("easyenclave: init: dhcp lease acquired");
-                    // Diagnostic: dump routing table so serial shows
-                    // whether the default route + on-link gateway landed.
-                    let _ = std::process::Command::new("ip")
-                        .args(["route", "show"])
-                        .status();
-                    let _ = std::process::Command::new("ip")
-                        .args(["addr", "show", "dev", iface])
-                        .status();
                 }
                 Ok(s) => {
                     eprintln!("easyenclave: init: udhcpc exited with {s}");


### PR DESCRIPTION
## Summary

Replace the single-grep smoke test (\`easyenclave: listening on\`) with a **boot-chain checklist** that validates 10 stages of the sealed VM boot. Streams serial output to the Action log and prints a summary checklist at the end.

## Motivation

We spent PRs #50–#61 (11 layers!) debugging dd staging failures that the old smoke test couldn't catch. The VM reached \`listening on\` even when networking was broken, DNS was misconfigured, metadata fetch failed, and no workloads deployed. Each issue was only discovered by manually pulling serial-port-output from GCP.

## Checklist markers

| # | Marker | Required? | Catches |
|---|---|---|---|
| 1 | \`Run /init as init process\` | yes | Kernel/initrd boot failure |
| 2 | \`Resolved root to /dev/\` | yes | findfs / LABEL= failure |
| 3 | \`easyenclave: running as PID 1\` | yes | switch_root failure |
| 4 | \`mounted /var/lib/easyenclave\` | yes | Tmpfs mount failure |
| 5 | \`attestation backend: tdx\` | yes | Missing TDX driver |
| 6 | \`Device link is up\` | yes | Missing gve/virtio_net (#55) |
| 7 | \`lease.*obtained\` | yes | DHCP failure (#50, #56, #57) |
| 8 | \`default via.*dev\` | yes | Route scope bug (#60) |
| 9 | \`dns from dhcp lease\` | yes | DNS bind-mount failure (#61) |
| 10 | \`gce-meta env\` | optional | Smoke VM has no ee-config |
| 11 | \`easyenclave: listening on\` | yes | Socket server failure |

## Example output

\`\`\`
=== easyenclave smoke test results (3971290f651f) ===
  ✓ kernel_boot
  ✓ root_resolved
  ✓ easyenclave_pid1
  ✓ tmpfs_mounted
  ✓ tdx_attestation
  ✓ network_up
  ✓ dhcp_lease
  ✓ default_route
  ✓ dns_configured
  - gce_metadata  (optional, not expected on smoke VM)
  ✓ listening

10/10 required checks passed

✓ image 3971290f651f passed all required smoke checks
\`\`\`

## Also in this PR

Remove debug diagnostic lines from #58 (udhcpc-hook echo) and #59 (\`ip route show\` / \`ip addr show\` after DHCP). The checklist replaces their diagnostic value. The metadata fetch error logging from #59 is kept (useful production logging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)