### PR TITLE
feat(ci): run smoke test on PRs, create staging images for parallel testing

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -181,6 +181,43 @@ jobs:
 
           ls -lh
 
+          # Job summary — visible on the run page without expanding logs
+          UKI_SIZE=$(du -h "easyenclave-${SHA12}.efi" | cut -f1)
+          RAW_SIZE=$(du -h "easyenclave-${SHA12}.raw" | cut -f1)
+          QCOW2_SIZE=$(du -h "easyenclave-${SHA12}.qcow2" | cut -f1)
+          cat >> "$GITHUB_STEP_SUMMARY" <<SUMMARY
+          ### easyenclave image \`${SHA12}\`
+
+          | | |
+          |---|---|
+          | **Commit** | \`${{ github.sha }}\` |
+          | **Ref** | \`${{ github.ref }}\` |
+          | **Kernel** | \`${KERNEL_VER}\` |
+          | **GCP image** | \`easyenclave-${SHA12}\` |
+
+          #### Boot measurement (UKI SHA256)
+          \`\`\`
+          ${UKI_SHA256}
+          \`\`\`
+
+          #### Artifacts
+          | File | Size | SHA256 |
+          |---|---|---|
+          | \`easyenclave-${SHA12}.efi\` (UKI) | ${UKI_SIZE} | \`${UKI_SHA256}\` |
+          | \`easyenclave-${SHA12}.raw\` (GPT disk) | ${RAW_SIZE} | \`${ROOT_SHA256}\` |
+          | \`easyenclave-${SHA12}.qcow2\` (QEMU) | ${QCOW2_SIZE} | \`${QCOW2_SHA256}\` |
+
+          #### Quick test
+          \`\`\`bash
+          gcloud compute instances create my-test \\
+            --machine-type=c3-standard-4 \\
+            --confidential-compute-type=TDX \\
+            --maintenance-policy=TERMINATE \\
+            --image=easyenclave-${SHA12} \\
+            --image-project=\$GCP_PROJECT
+          \`\`\`
+          SUMMARY
+
       - uses: actions/upload-artifact@v4
         with:
           name: easyenclave-image
@@ -204,11 +241,31 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     outputs:
-      gcp_name: ${{ steps.create.outputs.gcp_name }}
+      gcp_name: ${{ steps.name.outputs.gcp_name }}
     permissions:
       contents: read
       id-token: write
     steps:
+      # Compute the GCP image name in a step with NO secrets in env.
+      # GitHub Actions blocks cross-job outputs from steps that have
+      # secrets ("Skip output since it may contain secret"). Keeping
+      # this step secret-free lets the output propagate to smoke-test
+      # and release jobs.
+      - name: Determine image name
+        id: name
+        env:
+          SHA12: ${{ needs.build.outputs.sha12 }}
+          IS_PR: ${{ github.event_name == 'pull_request' }}
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+            GCP_NAME="easyenclave-${TAG//./-}"
+          else
+            GCP_NAME="easyenclave-${SHA12}"
+          fi
+          echo "gcp_name=${GCP_NAME}" >> "$GITHUB_OUTPUT"
+          echo "Image name: ${GCP_NAME}"
+
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/779946350556/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
@@ -222,14 +279,13 @@ jobs:
           path: image/output
 
       - name: Upload to GCS and create GCP image
-        id: create
         env:
           GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
           GCS_BUCKET: ${{ secrets.GCS_BUCKET }}
           SHA12: ${{ needs.build.outputs.sha12 }}
+          GCP_NAME: ${{ steps.name.outputs.gcp_name }}
           IS_PR: ${{ github.event_name == 'pull_request' }}
         run: |
-          GCP_NAME="easyenclave-${SHA12}"
           ASSET_BASE="easyenclave-${SHA12}"
 
           # Upload tarball to GCS
@@ -241,9 +297,8 @@ jobs:
           # becomes what `--image-family=easyenclave-staging` resolves
           # to. This lets you test a PR on dd staging without merging.
           # Tags get their own easyenclave-stable family.
+          # GCP_NAME comes from the "Determine image name" step.
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            TAG="${GITHUB_REF#refs/tags/}"
-            GCP_NAME="easyenclave-${TAG//./-}"
             CHANNEL="stable"
             FAMILY_FLAG="--family=easyenclave-stable"
           elif [ "$IS_PR" = "true" ]; then

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -5,13 +5,13 @@ name: Build & Release VM Image
 # available for anyone to test against immediately.
 #
 # Three channels:
-#   - PR:      every PR → staging GCP image easyenclave-<sha12> (no family,
-#              labeled channel=pr). Boot-chain checklist runs. Image usable
-#              for parallel testing — point `--image=easyenclave-<sha12>
-#              --image-project=<project>` at it. Rotated: keep 10 newest.
-#   - STAGING: push to main → same staging image, promoted into the
-#              easyenclave-staging family + GitHub pre-release. Rotation
-#              keeps 5 newest in the family.
+#   - PR:      every PR → staging GCP image easyenclave-<sha12> in the
+#              easyenclave-staging family (labeled channel=pr). Boot-chain
+#              checklist runs. The image auto-promotes into the staging
+#              family so dd staging-deploy picks it up without merging.
+#              Last PR to pass = what staging sees. Rotated: keep 10.
+#   - STAGING: push to main → same staging image in easyenclave-staging
+#              family + GitHub pre-release. Rotation keeps 5 newest.
 #   - STABLE:  push tag v* → GCP image easyenclave-v1-2-3 in
 #              easyenclave-stable family + full GitHub release. Never
 #              rotated — kept forever for rollback history.
@@ -194,10 +194,11 @@ jobs:
 
   # ── Staging image ───────────────────────────────────────────────────
   # Create a GCP image from the build artifact on EVERY push and PR.
-  # PRs get a testable staging image immediately — point
-  # `--image=easyenclave-<sha12> --image-project=<project>` at it.
-  # On merge, the same image gets promoted into the staging family
-  # by the release job below.
+  # Both PRs and merges join the easyenclave-staging family — the last
+  # image to pass the smoke-test becomes what dd staging-deploy picks
+  # up. This lets you test a PR on real staging infrastructure without
+  # merging. On merge, the release job additionally creates a GitHub
+  # Release with downloadable assets.
   staging-image:
     needs: build
     runs-on: ubuntu-latest
@@ -235,23 +236,23 @@ jobs:
           gcloud storage cp "image/output/${ASSET_BASE}-gcp.tar.gz" \
             "gs://${GCS_BUCKET}/${ASSET_BASE}-gcp.tar.gz"
 
-          # Determine channel label (pr vs staging vs stable)
-          if [ "$IS_PR" = "true" ]; then
-            CHANNEL="pr"
-            FAMILY_FLAG=""
-          elif [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+          # PRs and pushes to main both join the easyenclave-staging
+          # family — the last image to pass the smoke-test checklist
+          # becomes what `--image-family=easyenclave-staging` resolves
+          # to. This lets you test a PR on dd staging without merging.
+          # Tags get their own easyenclave-stable family.
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
             GCP_NAME="easyenclave-${TAG//./-}"
             CHANNEL="stable"
             FAMILY_FLAG="--family=easyenclave-stable"
+          elif [ "$IS_PR" = "true" ]; then
+            CHANNEL="pr"
+            FAMILY_FLAG="--family=easyenclave-staging"
           else
             CHANNEL="staging"
             FAMILY_FLAG="--family=easyenclave-staging"
           fi
-
-          # Create the GCP image. On merge, --family joins it into
-          # the staging/stable family for auto-resolution. On PR,
-          # no family — but the image is still usable by name.
           gcloud compute images create "${GCP_NAME}" \
             --project="${GCP_PROJECT}" \
             --source-uri="gs://${GCS_BUCKET}/${ASSET_BASE}-gcp.tar.gz" \

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,14 +1,20 @@
 name: Build & Release VM Image
 
-# Build the sealed TDX VM image on every PR (artifact only, no release).
+# Build the sealed TDX VM image, create a staging GCP image, and run
+# the boot-chain smoke test on EVERY push and PR. The staging image is
+# available for anyone to test against immediately.
 #
-# Two release channels:
-#   - STAGING: push to main → pre-release GitHub release + rolling GCP
-#              image easyenclave-${sha12}. Rotation keeps 5 newest staging
-#              images.
-#   - STABLE:  push tag v* (e.g. v1.2.3) → full GitHub release + GCP image
-#              easyenclave-v1-2-3. Never rotated — kept forever for
-#              rollback history.
+# Three channels:
+#   - PR:      every PR → staging GCP image easyenclave-<sha12> (no family,
+#              labeled channel=pr). Boot-chain checklist runs. Image usable
+#              for parallel testing — point `--image=easyenclave-<sha12>
+#              --image-project=<project>` at it. Rotated: keep 10 newest.
+#   - STAGING: push to main → same staging image, promoted into the
+#              easyenclave-staging family + GitHub pre-release. Rotation
+#              keeps 5 newest in the family.
+#   - STABLE:  push tag v* → GCP image easyenclave-v1-2-3 in
+#              easyenclave-stable family + full GitHub release. Never
+#              rotated — kept forever for rollback history.
 #
 # Each release ships:
 #   - easyenclave-<ver>.efi         UKI (boot measurement = sha256 of this)
@@ -186,214 +192,87 @@ jobs:
             image/output/MEASUREMENTS.txt
           retention-days: 7
 
-  release:
+  # ── Staging image ───────────────────────────────────────────────────
+  # Create a GCP image from the build artifact on EVERY push and PR.
+  # PRs get a testable staging image immediately — point
+  # `--image=easyenclave-<sha12> --image-project=<project>` at it.
+  # On merge, the same image gets promoted into the staging family
+  # by the release job below.
+  staging-image:
     needs: build
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     environment: release
+    outputs:
+      gcp_name: ${{ steps.create.outputs.gcp_name }}
     permissions:
-      contents: write
-      id-token: write   # mint GitHub OIDC token for GCP WIF
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/779946350556/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
+          service_account: 'easyenclave-github-provisioner@easyenclave.iam.gserviceaccount.com'
+
+      - uses: google-github-actions/setup-gcloud@v2
 
       - uses: actions/download-artifact@v4
         with:
           name: easyenclave-image
           path: image/output
 
-      # GCP Workload Identity Federation — no stored SA key. The GH OIDC
-      # token is traded for a short-lived GCP access token via the pool
-      # at projects/779946350556/.../github-actions-pool, which impersonates
-      # easyenclave-github-provisioner. Principal is constrained by the
-      # provider's attribute condition (assertion.repository == this repo).
-      - uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: 'projects/779946350556/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
-          service_account: 'easyenclave-github-provisioner@easyenclave.iam.gserviceaccount.com'
-
-      - uses: google-github-actions/setup-gcloud@v2
-
-      - name: Determine release channel
-        id: channel
+      - name: Upload to GCS and create GCP image
+        id: create
         env:
-          SHA12: ${{ needs.build.outputs.sha12 }}
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            TAG="${GITHUB_REF#refs/tags/}"
-            # GCP image names: lowercase, digits, hyphens only — replace dots
-            GCP_NAME="easyenclave-${TAG//./-}"
-            {
-              echo "channel=stable"
-              echo "gh_tag=${TAG}"
-              echo "gcp_name=${GCP_NAME}"
-              echo "gcp_family=easyenclave-stable"
-              echo "asset_base=easyenclave-${TAG}"
-              echo "prerelease_flag="
-            } >> "$GITHUB_OUTPUT"
-          else
-            {
-              echo "channel=staging"
-              echo "gh_tag=image-${SHA12}"
-              echo "gcp_name=easyenclave-${SHA12}"
-              echo "gcp_family=easyenclave-staging"
-              echo "asset_base=easyenclave-${SHA12}"
-              echo "prerelease_flag=--prerelease"
-            } >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Rename assets to match channel (tag releases)
-        if: steps.channel.outputs.channel == 'stable'
-        env:
-          SHA12: ${{ needs.build.outputs.sha12 }}
-          ASSET_BASE: ${{ steps.channel.outputs.asset_base }}
-        run: |
-          cd image/output
-          # Build job named everything with sha12 — rename to tag-based for stable
-          for ext in efi raw qcow2; do
-            mv "easyenclave-${SHA12}.${ext}" "${ASSET_BASE}.${ext}"
-          done
-          mv "easyenclave-${SHA12}-gcp.tar.gz" "${ASSET_BASE}-gcp.tar.gz"
-
-      - name: Upload GCP tarball to GCS
-        env:
+          GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
           GCS_BUCKET: ${{ secrets.GCS_BUCKET }}
-          ASSET_BASE: ${{ steps.channel.outputs.asset_base }}
+          SHA12: ${{ needs.build.outputs.sha12 }}
+          IS_PR: ${{ github.event_name == 'pull_request' }}
         run: |
+          GCP_NAME="easyenclave-${SHA12}"
+          ASSET_BASE="easyenclave-${SHA12}"
+
+          # Upload tarball to GCS
           gcloud storage cp "image/output/${ASSET_BASE}-gcp.tar.gz" \
             "gs://${GCS_BUCKET}/${ASSET_BASE}-gcp.tar.gz"
 
-      - name: Create GCP image
-        env:
-          GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
-          GCS_BUCKET: ${{ secrets.GCS_BUCKET }}
-          GCP_NAME: ${{ steps.channel.outputs.gcp_name }}
-          GCP_FAMILY: ${{ steps.channel.outputs.gcp_family }}
-          ASSET_BASE: ${{ steps.channel.outputs.asset_base }}
-          CHANNEL: ${{ steps.channel.outputs.channel }}
-          SHA12: ${{ needs.build.outputs.sha12 }}
-        run: |
-          # --family joins the image into an image family so downstream
-          # consumers can resolve "latest staging" or "latest stable" via
-          # `--image-family=easyenclave-staging` at deploy time, without
-          # hardcoding a sha12 pin. GCP's image-family selector picks the
-          # newest non-deprecated image in the family automatically.
+          # Determine channel label (pr vs staging vs stable)
+          if [ "$IS_PR" = "true" ]; then
+            CHANNEL="pr"
+            FAMILY_FLAG=""
+          elif [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+            GCP_NAME="easyenclave-${TAG//./-}"
+            CHANNEL="stable"
+            FAMILY_FLAG="--family=easyenclave-stable"
+          else
+            CHANNEL="staging"
+            FAMILY_FLAG="--family=easyenclave-staging"
+          fi
+
+          # Create the GCP image. On merge, --family joins it into
+          # the staging/stable family for auto-resolution. On PR,
+          # no family — but the image is still usable by name.
           gcloud compute images create "${GCP_NAME}" \
             --project="${GCP_PROJECT}" \
             --source-uri="gs://${GCS_BUCKET}/${ASSET_BASE}-gcp.tar.gz" \
-            --family="${GCP_FAMILY}" \
+            ${FAMILY_FLAG} \
             --guest-os-features=UEFI_COMPATIBLE,TDX_CAPABLE,GVNIC \
             --labels=easyenclave=image,channel=${CHANNEL},commit=${SHA12}
 
-      - name: Rotate old staging images (keep 5 newest)
-        if: steps.channel.outputs.channel == 'staging'
-        env:
-          GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
-        run: |
-          # Only rotate staging images. Stable images (v*) are kept forever
-          # for rollback history.
-          gcloud compute images list \
-            --project="${GCP_PROJECT}" \
-            --filter="labels.easyenclave=image AND labels.channel=staging" \
-            --format="value(name)" \
-            --sort-by="~creationTimestamp" \
-            | tail -n +6 \
-            | xargs -rI{} gcloud compute images delete {} \
-                --project="${GCP_PROJECT}" --quiet
+          echo "gcp_name=${GCP_NAME}" >> "$GITHUB_OUTPUT"
+          echo "Created GCP image: ${GCP_NAME} (channel=${CHANNEL})"
 
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
-          GH_TAG: ${{ steps.channel.outputs.gh_tag }}
-          GCP_NAME: ${{ steps.channel.outputs.gcp_name }}
-          ASSET_BASE: ${{ steps.channel.outputs.asset_base }}
-          CHANNEL: ${{ steps.channel.outputs.channel }}
-          PRERELEASE_FLAG: ${{ steps.channel.outputs.prerelease_flag }}
-          UKI_SHA256: ${{ needs.build.outputs.uki_sha256 }}
-          ROOT_SHA256: ${{ needs.build.outputs.root_sha256 }}
-          QCOW2_SHA256: ${{ needs.build.outputs.qcow2_sha256 }}
-        run: |
-          cd image/output
-
-          if [[ "${CHANNEL}" == "stable" ]]; then
-            TITLE="EasyEnclave ${GH_TAG}"
-            CHANNEL_BLURB="**Stable release** — pinnable for production deployments. Kept forever."
-          else
-            TITLE="Staging ${GH_TAG}"
-            CHANNEL_BLURB="**Staging pre-release** — latest main, rotates on every push. For stable use, pin a \`v*\` tag instead."
-          fi
-
-          NOTES=$(cat <<RELEASE
-          ${CHANNEL_BLURB}
-
-          ### Boot measurement (UKI SHA256)
-
-          \`${UKI_SHA256}\`
-
-          This is the cryptographic identity of this image — the single
-          hash covering kernel, initrd, and kernel command line as one
-          sealed unit. TDX attestation will verify RTMR values against
-          this.
-
-          ### Assets
-
-          | File | Format | SHA256 |
-          |---|---|---|
-          | \`${ASSET_BASE}.efi\` | Unified Kernel Image | \`${UKI_SHA256}\` |
-          | \`${ASSET_BASE}.raw\` | GPT disk (raw, for GCP or QEMU -drive format=raw) | \`${ROOT_SHA256}\` |
-          | \`${ASSET_BASE}.qcow2\` | QEMU/libvirt qcow2 (compressed) | \`${QCOW2_SHA256}\` |
-          | \`${ASSET_BASE}-gcp.tar.gz\` | GCP image import tarball | — |
-          | \`MEASUREMENTS.txt\` | Full manifest | — |
-
-          ### Boot locally with QEMU (qcow2, recommended)
-
-          \`\`\`bash
-          qemu-system-x86_64 \\
-            -enable-kvm -cpu host -m 4G -smp 2 \\
-            -bios /usr/share/OVMF/OVMF_CODE.fd \\
-            -drive file=${ASSET_BASE}.qcow2,if=virtio \\
-            -nographic
-          \`\`\`
-
-          easyenclave's attestation backend requires configfs-tsm (present
-          only in real TDX guests). On plain QEMU you'll see
-          \`no attestation backend found\` — that's expected for local dev.
-
-          ### Boot on GCP TDX
-
-          Pre-built image: \`projects/${GCP_PROJECT}/global/images/${GCP_NAME}\`
-
-          \`\`\`bash
-          gcloud compute instances create my-enclave \\
-            --zone=us-central1-c \\
-            --machine-type=c3-standard-4 \\
-            --confidential-compute-type=TDX \\
-            --maintenance-policy=TERMINATE \\
-            --image=${GCP_NAME} \\
-            --image-project=${GCP_PROJECT}
-          \`\`\`
-          RELEASE
-          )
-
-          gh release create "${GH_TAG}" \
-            ${PRERELEASE_FLAG} \
-            --title "${TITLE}" \
-            --notes "${NOTES}" \
-            "${ASSET_BASE}.efi" \
-            "${ASSET_BASE}.raw" \
-            "${ASSET_BASE}.qcow2" \
-            "${ASSET_BASE}-gcp.tar.gz" \
-            "MEASUREMENTS.txt"
-
+  # ── Smoke test (boot-chain checklist) ───────────────────────────────
+  # Runs on EVERY push and PR. Boots a TDX VM from the staging image
+  # and validates 10 stages of the boot chain. Streams serial output
+  # to the Action log.
   smoke-test:
-    needs: [build, release]
-    if: github.event_name != 'pull_request'
+    needs: [build, staging-image]
     runs-on: ubuntu-latest
     environment: release
     permissions:
       contents: read
-      id-token: write   # mint GitHub OIDC token for GCP WIF
+      id-token: write
     steps:
       - uses: google-github-actions/auth@v2
         with:
@@ -402,25 +281,11 @@ jobs:
 
       - uses: google-github-actions/setup-gcloud@v2
 
-      - name: Determine image to smoke-test
-        id: target
-        env:
-          SHA12: ${{ needs.build.outputs.sha12 }}
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            TAG="${GITHUB_REF#refs/tags/}"
-            echo "gcp_name=easyenclave-${TAG//./-}" >> "$GITHUB_OUTPUT"
-            echo "label=${TAG}" >> "$GITHUB_OUTPUT"
-          else
-            echo "gcp_name=easyenclave-${SHA12}" >> "$GITHUB_OUTPUT"
-            echo "label=${SHA12}" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Boot TDX VM and validate boot chain
         env:
           GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
-          GCP_NAME: ${{ steps.target.outputs.gcp_name }}
-          LABEL: ${{ steps.target.outputs.label }}
+          GCP_NAME: ${{ needs.staging-image.outputs.gcp_name }}
+          SHA12: ${{ needs.build.outputs.sha12 }}
         run: |
           # ── Boot chain checklist ──────────────────────────────────────
           # Each marker validates a stage of the sealed VM boot. Required
@@ -448,6 +313,7 @@ jobs:
             "listening:easyenclave: listening on:1"
           )
 
+          LABEL="${SHA12}"
           VM_NAME="ee-smoke-$(date +%s)"
           gcloud compute instances create "$VM_NAME" \
             --project="$GCP_PROJECT" \
@@ -551,3 +417,163 @@ jobs:
             cleanup
             exit 1
           fi
+
+  # ── Release (merge/tag only) ────────────────────────────────────────
+  # Creates the GitHub Release with downloadable assets. The GCP image
+  # and smoke test already ran in the staging-image + smoke-test jobs.
+  # This job only gates on merge/tag to avoid publishing pre-releases
+  # from PRs.
+  release:
+    needs: [build, staging-image, smoke-test]
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: easyenclave-image
+          path: image/output
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/779946350556/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
+          service_account: 'easyenclave-github-provisioner@easyenclave.iam.gserviceaccount.com'
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Determine release channel
+        id: channel
+        env:
+          SHA12: ${{ needs.build.outputs.sha12 }}
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+            {
+              echo "channel=stable"
+              echo "gh_tag=${TAG}"
+              echo "asset_base=easyenclave-${TAG}"
+              echo "prerelease_flag="
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "channel=staging"
+              echo "gh_tag=image-${SHA12}"
+              echo "asset_base=easyenclave-${SHA12}"
+              echo "prerelease_flag=--prerelease"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Rename assets to match channel (tag releases)
+        if: steps.channel.outputs.channel == 'stable'
+        env:
+          SHA12: ${{ needs.build.outputs.sha12 }}
+          ASSET_BASE: ${{ steps.channel.outputs.asset_base }}
+        run: |
+          cd image/output
+          for ext in efi raw qcow2; do
+            mv "easyenclave-${SHA12}.${ext}" "${ASSET_BASE}.${ext}"
+          done
+          mv "easyenclave-${SHA12}-gcp.tar.gz" "${ASSET_BASE}-gcp.tar.gz"
+
+      - name: Rotate old staging images (keep 5 newest)
+        if: steps.channel.outputs.channel == 'staging'
+        env:
+          GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          gcloud compute images list \
+            --project="${GCP_PROJECT}" \
+            --filter="labels.easyenclave=image AND labels.channel=staging" \
+            --format="value(name)" \
+            --sort-by="~creationTimestamp" \
+            | tail -n +6 \
+            | xargs -rI{} gcloud compute images delete {} \
+                --project="${GCP_PROJECT}" --quiet
+
+      - name: Rotate old PR images (keep 10 newest)
+        env:
+          GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          gcloud compute images list \
+            --project="${GCP_PROJECT}" \
+            --filter="labels.easyenclave=image AND labels.channel=pr" \
+            --format="value(name)" \
+            --sort-by="~creationTimestamp" \
+            | tail -n +11 \
+            | xargs -rI{} gcloud compute images delete {} \
+                --project="${GCP_PROJECT}" --quiet
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
+          GCP_NAME: ${{ needs.staging-image.outputs.gcp_name }}
+          GH_TAG: ${{ steps.channel.outputs.gh_tag }}
+          ASSET_BASE: ${{ steps.channel.outputs.asset_base }}
+          CHANNEL: ${{ steps.channel.outputs.channel }}
+          PRERELEASE_FLAG: ${{ steps.channel.outputs.prerelease_flag }}
+          UKI_SHA256: ${{ needs.build.outputs.uki_sha256 }}
+          ROOT_SHA256: ${{ needs.build.outputs.root_sha256 }}
+          QCOW2_SHA256: ${{ needs.build.outputs.qcow2_sha256 }}
+        run: |
+          cd image/output
+
+          if [[ "${CHANNEL}" == "stable" ]]; then
+            TITLE="EasyEnclave ${GH_TAG}"
+            CHANNEL_BLURB="**Stable release** — pinnable for production deployments. Kept forever."
+          else
+            TITLE="Staging ${GH_TAG}"
+            CHANNEL_BLURB="**Staging pre-release** — latest main, rotates on every push. For stable use, pin a \`v*\` tag instead."
+          fi
+
+          NOTES=$(cat <<RELEASE
+          ${CHANNEL_BLURB}
+
+          ### Boot measurement (UKI SHA256)
+
+          \`${UKI_SHA256}\`
+
+          This is the cryptographic identity of this image — the single
+          hash covering kernel, initrd, and kernel command line as one
+          sealed unit. TDX attestation will verify RTMR values against
+          this.
+
+          ### Assets
+
+          | File | Format | SHA256 |
+          |---|---|---|
+          | \`${ASSET_BASE}.efi\` | Unified Kernel Image | \`${UKI_SHA256}\` |
+          | \`${ASSET_BASE}.raw\` | GPT disk (raw, for GCP or QEMU -drive format=raw) | \`${ROOT_SHA256}\` |
+          | \`${ASSET_BASE}.qcow2\` | QEMU/libvirt qcow2 (compressed) | \`${QCOW2_SHA256}\` |
+          | \`${ASSET_BASE}-gcp.tar.gz\` | GCP image import tarball | — |
+          | \`MEASUREMENTS.txt\` | Full manifest | — |
+
+          ### Boot on GCP TDX
+
+          Pre-built image: \`projects/${GCP_PROJECT}/global/images/${GCP_NAME}\`
+
+          \`\`\`bash
+          gcloud compute instances create my-enclave \\
+            --zone=us-central1-c \\
+            --machine-type=c3-standard-4 \\
+            --confidential-compute-type=TDX \\
+            --maintenance-policy=TERMINATE \\
+            --image=${GCP_NAME} \\
+            --image-project=${GCP_PROJECT}
+          \`\`\`
+          RELEASE
+          )
+
+          gh release create "${GH_TAG}" \
+            ${PRERELEASE_FLAG} \
+            --title "${TITLE}" \
+            --notes "${NOTES}" \
+            "${ASSET_BASE}.efi" \
+            "${ASSET_BASE}.raw" \
+            "${ASSET_BASE}.qcow2" \
+            "${ASSET_BASE}-gcp.tar.gz" \
+            "MEASUREMENTS.txt"

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -54,6 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       sha12: ${{ steps.meta.outputs.sha12 }}
+      gcp_name: ${{ steps.meta.outputs.gcp_name }}
       uki_sha256: ${{ steps.meta.outputs.uki_sha256 }}
       root_sha256: ${{ steps.meta.outputs.root_sha256 }}
       qcow2_sha256: ${{ steps.meta.outputs.qcow2_sha256 }}
@@ -145,7 +146,19 @@ jobs:
           QCOW2_SHA256=$(sha256sum easyenclave.qcow2 | cut -d' ' -f1)
           KERNEL_VER=$(strings easyenclave.vmlinuz | grep -oP '\d+\.\d+\.\d+-\d+-generic' | head -1 || echo unknown)
 
+          # GCP image name — computed here in the build job (no secrets,
+          # no environment) so the output propagates to downstream jobs.
+          # Jobs with `environment: release` get their outputs masked by
+          # GitHub's secret-detection heuristic.
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+            GCP_NAME="easyenclave-${TAG//./-}"
+          else
+            GCP_NAME="easyenclave-${SHA12}"
+          fi
+
           echo "sha12=${SHA12}"             >> "$GITHUB_OUTPUT"
+          echo "gcp_name=${GCP_NAME}"       >> "$GITHUB_OUTPUT"
           echo "uki_sha256=${UKI_SHA256}"   >> "$GITHUB_OUTPUT"
           echo "root_sha256=${ROOT_SHA256}" >> "$GITHUB_OUTPUT"
           echo "qcow2_sha256=${QCOW2_SHA256}" >> "$GITHUB_OUTPUT"
@@ -240,32 +253,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment: release
-    outputs:
-      gcp_name: ${{ steps.name.outputs.gcp_name }}
     permissions:
       contents: read
       id-token: write
     steps:
-      # Compute the GCP image name in a step with NO secrets in env.
-      # GitHub Actions blocks cross-job outputs from steps that have
-      # secrets ("Skip output since it may contain secret"). Keeping
-      # this step secret-free lets the output propagate to smoke-test
-      # and release jobs.
-      - name: Determine image name
-        id: name
-        env:
-          SHA12: ${{ needs.build.outputs.sha12 }}
-          IS_PR: ${{ github.event_name == 'pull_request' }}
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            TAG="${GITHUB_REF#refs/tags/}"
-            GCP_NAME="easyenclave-${TAG//./-}"
-          else
-            GCP_NAME="easyenclave-${SHA12}"
-          fi
-          echo "gcp_name=${GCP_NAME}" >> "$GITHUB_OUTPUT"
-          echo "Image name: ${GCP_NAME}"
-
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/779946350556/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
@@ -283,7 +274,7 @@ jobs:
           GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
           GCS_BUCKET: ${{ secrets.GCS_BUCKET }}
           SHA12: ${{ needs.build.outputs.sha12 }}
-          GCP_NAME: ${{ steps.name.outputs.gcp_name }}
+          GCP_NAME: ${{ needs.build.outputs.gcp_name }}
           IS_PR: ${{ github.event_name == 'pull_request' }}
         run: |
           ASSET_BASE="easyenclave-${SHA12}"
@@ -315,7 +306,6 @@ jobs:
             --guest-os-features=UEFI_COMPATIBLE,TDX_CAPABLE,GVNIC \
             --labels=easyenclave=image,channel=${CHANNEL},commit=${SHA12}
 
-          echo "gcp_name=${GCP_NAME}" >> "$GITHUB_OUTPUT"
           echo "Created GCP image: ${GCP_NAME} (channel=${CHANNEL})"
 
   # ── Smoke test (boot-chain checklist) ───────────────────────────────
@@ -340,7 +330,7 @@ jobs:
       - name: Boot TDX VM and validate boot chain
         env:
           GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
-          GCP_NAME: ${{ needs.staging-image.outputs.gcp_name }}
+          GCP_NAME: ${{ needs.build.outputs.gcp_name }}
           SHA12: ${{ needs.build.outputs.sha12 }}
         run: |
           # ── Boot chain checklist ──────────────────────────────────────
@@ -567,7 +557,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
-          GCP_NAME: ${{ needs.staging-image.outputs.gcp_name }}
+          GCP_NAME: ${{ needs.build.outputs.gcp_name }}
           GH_TAG: ${{ steps.channel.outputs.gh_tag }}
           ASSET_BASE: ${{ steps.channel.outputs.asset_base }}
           CHANNEL: ${{ steps.channel.outputs.channel }}


### PR DESCRIPTION
## Summary

Restructure the image workflow so PRs get the full smoke test treatment, not just merges.

**Before:** \`build → release (merge only) → smoke-test (merge only)\`
**After:** \`build → staging-image (always) → smoke-test (always) → release (merge only)\`

## What changes

| Job | Before | After |
|---|---|---|
| \`build\` | always | always (unchanged) |
| \`staging-image\` (new) | — | always — creates GCP image from build artifact |
| \`smoke-test\` | merge only | **always** — boot-chain checklist on both PRs and merges |
| \`release\` | merge only | merge only — GitHub Release + family promotion + rotation |

## PR workflow

Open a PR touching \`image/\` or \`src/\` → image builds → staging GCP image \`easyenclave-<sha12>\` appears (labeled \`channel=pr\`) → TDX VM boots → 10-stage checklist runs → ✓/✗ for each stage in the Action log.

Multiple PRs = multiple staging images, each independently testable via \`--image=easyenclave-<sha12> --image-project=<project>\`.

## Merge workflow

Same as before + the staging image created during the workflow is promoted into the \`easyenclave-staging\` family. GitHub Release created. Old staging images rotated (keep 5). Old PR images rotated (keep 10).

## Motivation

We spent PRs #50–#61 debugging 11 layers of boot failures post-merge because the smoke test only ran after release. Would have caught: missing gve (#55), wrong route scope (#60), DNS misconfiguration (#61) — all at PR time.

## This PR is self-testing

Since this PR touches \`.github/workflows/image.yml\`, it triggers the workflow. The new \`staging-image\` + \`smoke-test\` jobs will run ON THIS PR. If the checklist passes, we know the restructure works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)