### PR TITLE
fix: OCI pull + DNS resolution + cgroup mount — workloads deploy

### DIFF
--- a/image/test-local.sh
+++ b/image/test-local.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Boot easyenclave locally with TDX via direct kernel boot.
+#
+# Uses qemu -kernel/-initrd/-append (no OVMF, no Secure Boot).
+# TDX still works at the CPU level via -object tdx-guest.
+#
+# Usage:
+#   bash image/test-local.sh [agent.env]
+#
+# If agent.env is provided, a config ISO is built and attached as
+# a secondary disk. easyenclave reads /agent.env from it at boot
+# and applies the contents as env vars (EE_BOOT_WORKLOADS, etc.).
+#
+# Serial output goes to stdout — you see the boot chain live.
+# Ctrl-A X to quit qemu.
+#
+# Prerequisites:
+#   - qemu-system-x86_64
+#   - TDX-capable host (cat /sys/module/kvm_intel/parameters/tdx → Y)
+#   - genisoimage (only if passing agent.env)
+#   - Build artifacts in image/output/ (run `make build` first)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUTPUT_DIR="$SCRIPT_DIR/output"
+ENV_FILE="${1:-}"
+
+# ── Check prerequisites ──────────────────────────────────────────────
+for f in easyenclave.vmlinuz easyenclave.initrd easyenclave.cmdline easyenclave.qcow2; do
+    [ -f "$OUTPUT_DIR/$f" ] || { echo "Missing $OUTPUT_DIR/$f — run 'make build' first"; exit 1; }
+done
+
+command -v qemu-system-x86_64 >/dev/null || { echo "qemu-system-x86_64 not found"; exit 1; }
+
+TDX_SUPPORT=$(cat /sys/module/kvm_intel/parameters/tdx 2>/dev/null || echo "N")
+if [ "$TDX_SUPPORT" != "Y" ]; then
+    echo "WARNING: TDX not available on this host (kvm_intel.tdx=$TDX_SUPPORT)"
+    echo "         Booting without TDX — attestation will fail but everything else works."
+    TDX_FLAGS=""
+else
+    TDX_FLAGS="-machine q35,kernel-irqchip=split,confidential-guest-support=tdx -object tdx-guest,id=tdx"
+fi
+
+# ── Build config ISO (optional) ──────────────────────────────────────
+CONFIG_DRIVE=""
+if [ -n "$ENV_FILE" ]; then
+    [ -f "$ENV_FILE" ] || { echo "agent.env not found: $ENV_FILE"; exit 1; }
+    command -v genisoimage >/dev/null || { echo "genisoimage not found (apt install genisoimage)"; exit 1; }
+
+    CONFIG_ISO=$(mktemp --suffix=.iso)
+    trap 'rm -f "$CONFIG_ISO"' EXIT
+
+    genisoimage -quiet -o "$CONFIG_ISO" -V CONFIG -r -J "$ENV_FILE"
+    CONFIG_DRIVE="-drive file=$CONFIG_ISO,if=virtio,format=raw,media=cdrom,readonly=on"
+    echo "Config ISO: $CONFIG_ISO (from $ENV_FILE)"
+fi
+
+# ── Boot ─────────────────────────────────────────────────────────────
+CMDLINE=$(cat "$OUTPUT_DIR/easyenclave.cmdline")
+echo "Kernel:  $OUTPUT_DIR/easyenclave.vmlinuz"
+echo "Initrd:  $OUTPUT_DIR/easyenclave.initrd"
+echo "Cmdline: $CMDLINE"
+echo "Disk:    $OUTPUT_DIR/easyenclave.qcow2 (snapshot=on, never modified)"
+echo "Network: virtio-net + qemu user-mode (DHCP 10.0.2.x, DNS forwarded)"
+echo "TDX:     $TDX_SUPPORT"
+echo ""
+echo "Serial output below. Ctrl-A X to quit."
+echo "════════════════════════════════════════════════════════════════"
+
+# shellcheck disable=SC2086
+exec qemu-system-x86_64 \
+    -enable-kvm -cpu host -m 4G -smp 2 \
+    ${TDX_FLAGS:--machine q35} \
+    -kernel "$OUTPUT_DIR/easyenclave.vmlinuz" \
+    -initrd "$OUTPUT_DIR/easyenclave.initrd" \
+    -append "$CMDLINE" \
+    -drive "file=$OUTPUT_DIR/easyenclave.qcow2,if=virtio,format=qcow2,snapshot=on" \
+    $CONFIG_DRIVE \
+    -netdev user,id=n0 -device virtio-net-pci,netdev=n0 \
+    -serial mon:stdio \
+    -nographic

--- a/src/container.rs
+++ b/src/container.rs
@@ -61,17 +61,15 @@ async fn pull_image(image: &str, rootfs: &str) -> Result<(), String> {
     };
     let client = oci_distribution::Client::new(config);
 
+    // pull_image_manifest auto-resolves multi-arch image indexes to
+    // the linux/amd64 platform manifest via the client's built-in
+    // platform_resolver. No manual matching needed.
     let (manifest, _digest) = client
-        .pull_manifest(&reference, &RegistryAuth::Anonymous)
+        .pull_image_manifest(&reference, &RegistryAuth::Anonymous)
         .await
         .map_err(|e| format!("pull manifest: {e}"))?;
 
-    let layers = match &manifest {
-        oci_distribution::manifest::OciManifest::Image(m) => m.layers.clone(),
-        oci_distribution::manifest::OciManifest::ImageIndex(_) => {
-            return Err("image index not supported — specify a platform-specific tag".into());
-        }
-    };
+    let layers = manifest.layers.clone();
 
     for layer in &layers {
         let mut layer_data = Vec::new();

--- a/src/init.rs
+++ b/src/init.rs
@@ -22,6 +22,7 @@ pub fn maybe_init() {
         ("devtmpfs", "/dev", "devtmpfs"),
         ("tmpfs", "/tmp", "tmpfs"),
         ("tmpfs", "/run", "tmpfs"),
+        ("cgroup2", "/sys/fs/cgroup", "cgroup2"),
     ] {
         match nix_mount(src, target, fstype) {
             Ok(()) => eprintln!("easyenclave: init: mounted {target}"),
@@ -209,6 +210,19 @@ pub fn maybe_init() {
             "",
             libc::MS_BIND,
         );
+    }
+
+    // Force glibc to re-read /etc/resolv.conf. glibc caches the resolver
+    // config at process start — when /etc/resolv.conf was empty (the rootfs
+    // ships an empty placeholder for the bind-mount target). After the
+    // bind-mount above puts real nameservers in place, __res_init() forces
+    // glibc to pick them up. Without this, all DNS queries fail with
+    // "Temporary failure in name resolution".
+    extern "C" {
+        fn __res_init() -> libc::c_int;
+    }
+    unsafe {
+        __res_init();
     }
 
     // GCE instance metadata: fetch the `ee-config` attribute and apply


### PR DESCRIPTION
## Summary

Three fixes that together get workload deployment working end-to-end. **Locally validated** on a TDX Dell server — container starts, workload runs.

### 1. Multi-arch image index (\`container.rs\`)

\`pull_manifest()\` returned \`OciManifest::ImageIndex\` for multi-arch images. Switch to \`pull_image_manifest()\` which auto-resolves to linux/amd64.

### 2. DNS bind-mount + glibc cache (\`init.rs\` + \`mkosi.extra\`)

Two sub-issues:
- \`/etc/resolv.conf\` didn't exist on the read-only rootfs → bind-mount silently failed. Fix: empty placeholder in \`mkosi.extra/etc/resolv.conf\`.
- glibc caches resolver state at process start (before bind-mount). Fix: \`__res_init()\` after bind-mount.

### 3. cgroup2 mount (\`init.rs\`)

libcontainer needs \`/sys/fs/cgroup\`. Added to the mount list.

## Local validation

\`\`\`
✅ sealed VM boots, initrd loads modules
✅ DHCP lease (10.0.2.15)
✅ DNS resolves ghcr.io → [140.82.112.33]
✅ OCI manifest fetched (multi-arch → linux/amd64)
✅ layers downloaded and unpacked
✅ container smoke started (id=...)
\`\`\`

Also includes \`image/test-local.sh\` — direct kernel boot for local testing (no OVMF needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)