### PR TITLE
feat: harden native workloads and add smoke-admin CI

### DIFF
--- a/.github/SECRETS_SETUP.md
+++ b/.github/SECRETS_SETUP.md
@@ -1,5 +1,35 @@
 # GitHub Secrets Setup
 
+## VM Image Workflow Inputs
+
+The VM image pipeline now has two distinct stages:
+- Pull requests: build the VM image, publish a public `ee-smoke-admin` image to `ttl.sh`, and run a native integration test against a temporary GCP image.
+- Pushes to `main`: build the VM image, publish a public `ee-smoke-admin` image to `ttl.sh`, smoke-test a release candidate with that native static workload, then publish the verified image in the EasyEnclave GCP project by default.
+
+### Required for VM image publishing
+
+- `GCP_PROJECT_ID` secret: default GCP project used for PR image tests if `TEST_GCP_PROJECT_ID` is not set.
+- `GCS_BUCKET` secret: default bucket used to stage the raw disk tarball if `TEST_GCS_BUCKET` or `RELEASE_GCS_BUCKET` are not set.
+
+The workflow now generates a default `ee-config` automatically around the public `ee-smoke-admin` image, so no smoke-test workload variable is required for the default path.
+
+### Optional VM image variables
+
+- `TEST_GCP_PROJECT_ID`: override the PR-test project instead of using `GCP_PROJECT_ID`.
+- `TEST_GCS_BUCKET`: override the PR-test staging bucket instead of using `GCS_BUCKET`.
+- `TEST_ZONE`: override the default PR-test zone (`us-central1-c`).
+- `TEST_MACHINE_TYPE`: override the default PR-test machine type (`c3-standard-4`).
+- `PR_TEST_EE_CONFIG_JSON`: override the PR integration test workload. If set, it must still include at least one `"native": true` workload image because the PR smoke test now exercises the native path.
+- `RELEASE_GCP_PROJECT_ID`: override the release project instead of using `GCP_PROJECT_ID`.
+- `RELEASE_GCS_BUCKET`: override the release staging bucket instead of using `GCS_BUCKET`.
+- `RELEASE_ZONE`: override the default release smoke-test zone (`us-central1-c`).
+- `RELEASE_MACHINE_TYPE`: override the default release smoke-test machine type (`c3-standard-4`).
+- `RELEASE_TEST_EE_CONFIG_JSON`: override the default `ee-smoke-admin` release smoke-test workload. If set, it must include at least one `"native": true` workload image.
+- `RELEASE_IMAGE_PREFIX`: override the final image name prefix. Default: `easyenclave-release`.
+- `RELEASE_IMAGE_FAMILY`: override the final release image family. Default: `easyenclave-release`.
+- `GCP_WORKLOAD_IDENTITY_PROVIDER`: override the default GitHub Actions workload identity provider.
+- `GCP_SERVICE_ACCOUNT`: override the default GitHub Actions service account.
+
 ## Required Secrets for CI/CD
 
 ### Authentication & Billing Secrets

--- a/.github/scripts/smoke_test_gcp_vm.sh
+++ b/.github/scripts/smoke_test_gcp_vm.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  smoke_test_gcp_vm.sh \
+    --project <gcp-project> \
+    --zone <zone> \
+    --machine-type <machine-type> \
+    --image <image-name> \
+    --image-project <image-project> \
+    --metadata-file <ee-config.json> \
+    --mode <container-http|native-static> \
+    [--http-port <port>] \
+    [--http-path <path>]
+EOF
+}
+
+PROJECT=""
+ZONE=""
+MACHINE_TYPE=""
+IMAGE=""
+IMAGE_PROJECT=""
+METADATA_FILE=""
+MODE=""
+HTTP_PORT=""
+HTTP_PATH="/"
+FIREWALL_RULE="${FIREWALL_RULE:-ee-smoke-allow-http}"
+FIREWALL_TAG="${FIREWALL_TAG:-ee-smoke-test}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project) PROJECT="$2"; shift 2 ;;
+    --zone) ZONE="$2"; shift 2 ;;
+    --machine-type) MACHINE_TYPE="$2"; shift 2 ;;
+    --image) IMAGE="$2"; shift 2 ;;
+    --image-project) IMAGE_PROJECT="$2"; shift 2 ;;
+    --metadata-file) METADATA_FILE="$2"; shift 2 ;;
+    --mode) MODE="$2"; shift 2 ;;
+    --http-port) HTTP_PORT="$2"; shift 2 ;;
+    --http-path) HTTP_PATH="$2"; shift 2 ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+[[ -n "$PROJECT" ]] || { echo "missing --project" >&2; usage >&2; exit 1; }
+[[ -n "$ZONE" ]] || { echo "missing --zone" >&2; usage >&2; exit 1; }
+[[ -n "$MACHINE_TYPE" ]] || { echo "missing --machine-type" >&2; usage >&2; exit 1; }
+[[ -n "$IMAGE" ]] || { echo "missing --image" >&2; usage >&2; exit 1; }
+[[ -n "$IMAGE_PROJECT" ]] || { echo "missing --image-project" >&2; usage >&2; exit 1; }
+[[ -n "$METADATA_FILE" ]] || { echo "missing --metadata-file" >&2; usage >&2; exit 1; }
+[[ -f "$METADATA_FILE" ]] || { echo "metadata file not found: $METADATA_FILE" >&2; exit 1; }
+[[ "$MODE" == "container-http" || "$MODE" == "native-static" ]] || {
+  echo "mode must be one of: container-http, native-static" >&2
+  exit 1
+}
+
+VM_NAME="ee-${MODE//[^a-z]/-}-$(date +%s)"
+SERIAL_OUTPUT=""
+
+cleanup() {
+  gcloud compute instances delete "$VM_NAME" \
+    --project="$PROJECT" --zone="$ZONE" --quiet >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+if [[ "$MODE" == "container-http" ]]; then
+  HTTP_PORT="${HTTP_PORT:-80}"
+  HTTP_PATH="${HTTP_PATH:-/}"
+fi
+
+if [[ -n "$HTTP_PORT" ]]; then
+  gcloud compute firewall-rules describe "$FIREWALL_RULE" \
+    --project="$PROJECT" >/dev/null 2>&1 || \
+  gcloud compute firewall-rules create "$FIREWALL_RULE" \
+    --project="$PROJECT" \
+    --allow="tcp:${HTTP_PORT}" \
+    --target-tags="$FIREWALL_TAG" \
+    --source-ranges=0.0.0.0/0 \
+    --quiet
+fi
+
+INSTANCE_ARGS=(
+  --project="$PROJECT"
+  --zone="$ZONE"
+  --machine-type="$MACHINE_TYPE"
+  --confidential-compute-type=TDX
+  --maintenance-policy=TERMINATE
+  --image="$IMAGE"
+  --image-project="$IMAGE_PROJECT"
+  --boot-disk-size=10GB
+  --metadata-from-file="ee-config=$METADATA_FILE"
+)
+
+if [[ -n "$HTTP_PORT" ]]; then
+  INSTANCE_ARGS+=(--tags="$FIREWALL_TAG")
+fi
+
+gcloud compute instances create "$VM_NAME" "${INSTANCE_ARGS[@]}"
+
+COMMON_CHECKS=(
+  "kernel_boot:Run /init as init process:1"
+  "root_resolved:Resolved root to /dev/:1"
+  "easyenclave_pid1:easyenclave: running as PID 1:1"
+  "tmpfs_mounted:mounted /var/lib/easyenclave:1"
+  "cgroup_mounted:mounted /sys/fs/cgroup:1"
+  "tdx_attestation:attestation backend: tdx:1"
+  "network_up:Device link is up:1"
+  "dhcp_lease:lease of .* obtained:1"
+  "dns_configured:dns from dhcp lease:1"
+  "listening:easyenclave: listening on:1"
+)
+
+if [[ "$MODE" == "container-http" ]]; then
+  MODE_CHECKS=(
+    "container_started:container .* started:1"
+    "deployment_running:deployment .* running \\(container=:1"
+  )
+  FAIL_PATTERNS=(
+    "FATAL"
+    "Kernel panic"
+    "switch_root: can"
+    "Invalid ELF header"
+    "deployment .* failed"
+  )
+else
+  MODE_CHECKS=(
+    "native_pull:pulling .* \\(native static\\):1"
+    "native_running:deployment .* running native:1"
+  )
+  FAIL_PATTERNS=(
+    "FATAL"
+    "Kernel panic"
+    "switch_root: can"
+    "Invalid ELF header"
+    "native mode requires a static ELF executable"
+    "deployment .* failed"
+  )
+fi
+
+CHECKS=("${COMMON_CHECKS[@]}" "${MODE_CHECKS[@]}")
+declare -A PASSED=()
+LAST_LINES=0
+ALL_REQUIRED_DONE=false
+
+for i in $(seq 1 36); do
+  SERIAL_OUTPUT=$(gcloud compute instances get-serial-port-output "$VM_NAME" \
+    --project="$PROJECT" --zone="$ZONE" 2>/dev/null || true)
+
+  TOTAL_LINES=$(echo "$SERIAL_OUTPUT" | wc -l | tr -d ' ')
+  if [[ "$TOTAL_LINES" -gt "$LAST_LINES" ]]; then
+    echo "$SERIAL_OUTPUT" | tail -n +"$((LAST_LINES + 1))" | sed 's/^/[serial] /'
+    LAST_LINES="$TOTAL_LINES"
+  fi
+
+  for pattern in "${FAIL_PATTERNS[@]}"; do
+    if echo "$SERIAL_OUTPUT" | grep -qE "$pattern"; then
+      echo "::error::smoke test failed due to fatal serial pattern: $pattern"
+      echo "$SERIAL_OUTPUT" | tail -80
+      exit 1
+    fi
+  done
+
+  for check in "${CHECKS[@]}"; do
+    IFS=: read -r name pattern required <<<"$check"
+    [[ -n "${PASSED[$name]:-}" ]] && continue
+    if echo "$SERIAL_OUTPUT" | grep -qE "$pattern"; then
+      PASSED[$name]=1
+      echo "  ✓ $name"
+    fi
+  done
+
+  ALL_REQUIRED_DONE=true
+  for check in "${CHECKS[@]}"; do
+    IFS=: read -r name pattern required <<<"$check"
+    [[ "$required" == "0" ]] && continue
+    if [[ -z "${PASSED[$name]:-}" ]]; then
+      ALL_REQUIRED_DONE=false
+      break
+    fi
+  done
+
+  $ALL_REQUIRED_DONE && break
+  echo "  waiting... (${i}/36)"
+  sleep 10
+done
+
+HTTP_OK=false
+if [[ -n "$HTTP_PORT" && "$ALL_REQUIRED_DONE" == "true" ]]; then
+  VM_IP=$(gcloud compute instances describe "$VM_NAME" \
+    --project="$PROJECT" --zone="$ZONE" \
+    --format="value(networkInterfaces[0].accessConfigs[0].natIP)")
+  echo ""
+  echo "Testing HTTP on ${VM_IP}:${HTTP_PORT}${HTTP_PATH}..."
+  for i in $(seq 1 12); do
+    code=$(curl -sS -o /dev/null -w '%{http_code}' \
+      --connect-timeout 5 "http://${VM_IP}:${HTTP_PORT}${HTTP_PATH}" 2>/dev/null || echo 000)
+    if [[ "$code" == "200" ]]; then
+      echo "  ✓ http_probe (${VM_IP})"
+      HTTP_OK=true
+      break
+    fi
+    echo "  waiting... ${code} (${i}/12)"
+    sleep 5
+  done
+fi
+
+echo ""
+echo "=== smoke test (${MODE}) ==="
+PASS=0
+TOTAL=0
+for check in "${CHECKS[@]}"; do
+  IFS=: read -r name pattern required <<<"$check"
+  [[ "$required" == "1" ]] && TOTAL=$((TOTAL + 1))
+  if [[ -n "${PASSED[$name]:-}" ]]; then
+    echo "  ✓ $name"
+    [[ "$required" == "1" ]] && PASS=$((PASS + 1))
+  else
+    echo "  ✗ $name"
+  fi
+done
+
+if [[ -n "$HTTP_PORT" ]]; then
+  TOTAL=$((TOTAL + 1))
+  if [[ "$HTTP_OK" == "true" ]]; then
+    echo "  ✓ http_probe"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ http_probe"
+  fi
+fi
+
+echo "${PASS}/${TOTAL} passed"
+
+if [[ "$ALL_REQUIRED_DONE" != "true" ]]; then
+  echo "::error::smoke test did not reach all required serial checkpoints"
+  echo "$SERIAL_OUTPUT" | tail -80
+  exit 1
+fi
+
+if [[ -n "$HTTP_PORT" && "$HTTP_OK" != "true" ]]; then
+  echo "::error::smoke test never served HTTP 200"
+  echo "$SERIAL_OUTPUT" | tail -80
+  exit 1
+fi
+
+echo "✓ Smoke test passed"

--- a/.github/scripts/write_ee_config.py
+++ b/.github/scripts/write_ee_config.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate and write EasyEnclave ee-config JSON."
+    )
+    parser.add_argument("--json", required=True, help="Raw ee-config JSON object")
+    parser.add_argument("--output", required=True, help="Path to write the JSON file to")
+    parser.add_argument(
+        "--require-native-static",
+        action="store_true",
+        help="Require at least one boot workload with native=true and an image",
+    )
+    return parser.parse_args()
+
+
+def fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main() -> None:
+    args = parse_args()
+
+    try:
+        payload = json.loads(args.json)
+    except json.JSONDecodeError as exc:
+        fail(f"invalid ee-config JSON: {exc}")
+
+    if not isinstance(payload, dict):
+        fail("ee-config must be a JSON object")
+
+    if args.require_native_static:
+        boot_workloads_raw = payload.get("EE_BOOT_WORKLOADS")
+        if not isinstance(boot_workloads_raw, str) or not boot_workloads_raw.strip():
+            fail(
+                "release test config must define EE_BOOT_WORKLOADS as a JSON string "
+                "containing at least one native workload"
+            )
+
+        try:
+            boot_workloads = json.loads(boot_workloads_raw)
+        except json.JSONDecodeError as exc:
+            fail(f"EE_BOOT_WORKLOADS is not valid JSON: {exc}")
+
+        if not isinstance(boot_workloads, list):
+            fail("EE_BOOT_WORKLOADS must decode to a JSON array")
+
+        native_workloads = [
+            workload
+            for workload in boot_workloads
+            if isinstance(workload, dict)
+            and workload.get("native") is True
+            and isinstance(workload.get("image"), str)
+            and workload["image"].strip()
+        ]
+        if not native_workloads:
+            fail(
+                "release test config must include at least one boot workload with "
+                '"native": true and a non-empty "image"'
+            )
+
+    output_path = pathlib.Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,43 +1,46 @@
-name: Build & Release VM Image
-
-# Build the sealed TDX VM image and run a full integration test on
-# EVERY push and PR. PRs auto-promote into the staging family.
-#
-# Pipeline: build → deploy-and-test (staging image + integration
-#           test + release on merge)
+name: VM Image
 
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "image/**"
+      - "src/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "Dockerfile.smoke-admin"
+      - ".github/workflows/image.yml"
+      - ".github/scripts/**"
   push:
     branches: [main]
-    tags: ['v*']
     paths:
       - "image/**"
       - "src/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "Dockerfile.smoke-admin"
       - ".github/workflows/image.yml"
-  pull_request:
-    paths:
-      - "image/**"
-      - "src/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - ".github/workflows/image.yml"
+      - ".github/scripts/**"
   workflow_dispatch:
+    inputs:
+      release_test_config_json:
+        description: "Optional override for RELEASE_TEST_EE_CONFIG_JSON"
+        required: false
+        type: string
 
 concurrency:
-  group: easyenclave-image-${{ github.ref }}
+  group: easyenclave-vm-image-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
     outputs:
       sha12: ${{ steps.meta.outputs.sha12 }}
-      gcp_name: ${{ steps.meta.outputs.gcp_name }}
+      asset_base: ${{ steps.meta.outputs.asset_base }}
       uki_sha256: ${{ steps.meta.outputs.uki_sha256 }}
       root_sha256: ${{ steps.meta.outputs.root_sha256 }}
       qcow2_sha256: ${{ steps.meta.outputs.qcow2_sha256 }}
@@ -72,44 +75,43 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
-      - name: Build
+      - name: Build VM image
         env:
           KVER: ${{ steps.kver.outputs.kver }}
         run: |
           cargo build --release
           cd image && make build KVER="$KVER"
 
-      - name: Compute measurements
+      - name: Compute artifact metadata
         id: meta
         run: |
           cd image/output
           SHA12=$(echo "${{ github.sha }}" | cut -c1-12)
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            TAG="${GITHUB_REF#refs/tags/}"
-            GCP_NAME="easyenclave-${TAG//./-}"
-          else
-            GCP_NAME="easyenclave-${SHA12}"
-          fi
+          ASSET_BASE="easyenclave-${SHA12}"
           UKI_SHA256=$(sha256sum easyenclave.efi | cut -d' ' -f1)
           ROOT_SHA256=$(sha256sum easyenclave.root.raw | cut -d' ' -f1)
           QCOW2_SHA256=$(sha256sum easyenclave.qcow2 | cut -d' ' -f1)
+
           {
             echo "sha12=${SHA12}"
-            echo "gcp_name=${GCP_NAME}"
+            echo "asset_base=${ASSET_BASE}"
             echo "uki_sha256=${UKI_SHA256}"
             echo "root_sha256=${ROOT_SHA256}"
             echo "qcow2_sha256=${QCOW2_SHA256}"
           } >> "$GITHUB_OUTPUT"
-          mv easyenclave.efi "easyenclave-${SHA12}.efi"
-          mv easyenclave.root.raw "easyenclave-${SHA12}.raw"
-          mv easyenclave.qcow2 "easyenclave-${SHA12}.qcow2"
-          cp "easyenclave-${SHA12}.raw" disk.raw
-          tar -czf "easyenclave-${SHA12}-gcp.tar.gz" disk.raw
+
+          mv easyenclave.efi "${ASSET_BASE}.efi"
+          mv easyenclave.root.raw "${ASSET_BASE}.raw"
+          mv easyenclave.qcow2 "${ASSET_BASE}.qcow2"
+          cp "${ASSET_BASE}.raw" disk.raw
+          tar -czf "${ASSET_BASE}-gcp.tar.gz" disk.raw
           rm disk.raw
+
           cat > MEASUREMENTS.txt <<EOF
           commit: ${{ github.sha }}
           UKI sha256: ${UKI_SHA256}
           Disk sha256: ${ROOT_SHA256}
+          QCOW2 sha256: ${QCOW2_SHA256}
           EOF
 
       - uses: actions/upload-artifact@v4
@@ -123,228 +125,294 @@ jobs:
             image/output/MEASUREMENTS.txt
           retention-days: 7
 
-  # ── Deploy, test, and release (one GCP auth) ─────────────────────
-  deploy-and-test:
-    needs: build
+  publish-smoke-admin-image:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    outputs:
+      image_ref: ${{ steps.meta.outputs.image_ref }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compute public smoke-admin image ref
+        id: meta
+        run: |
+          SHA12=$(echo "${{ github.sha }}" | cut -c1-12)
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            IMAGE_REF="ttl.sh/easyenclave-smoke-admin-pr-${{ github.event.pull_request.number }}-${{ github.run_id }}-${SHA12}:24h"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            IMAGE_REF="ttl.sh/easyenclave-smoke-admin-main-${{ github.run_id }}-${SHA12}:24h"
+          else
+            IMAGE_REF="ttl.sh/easyenclave-smoke-admin-dispatch-${{ github.run_id }}-${SHA12}:24h"
+          fi
+          echo "image_ref=${IMAGE_REF}" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-buildx-action@v3
+      - name: Build and push public smoke-admin image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.smoke-admin
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          sbom: false
+          tags: ${{ steps.meta.outputs.image_ref }}
+
+  pr-integration-test:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    needs:
+      - build
+      - publish-smoke-admin-image
     runs-on: ubuntu-latest
     environment: release
     permissions:
-      contents: write
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
+      - uses: actions/setup-python@v5
         with:
-          workload_identity_provider: 'projects/779946350556/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
-          service_account: 'easyenclave-github-provisioner@easyenclave.iam.gserviceaccount.com'
-      - uses: google-github-actions/setup-gcloud@v2
+          python-version: "3.12"
       - uses: actions/download-artifact@v4
         with:
           name: easyenclave-image
           path: image/output
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER || 'projects/779946350556/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider' }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT || 'easyenclave-github-provisioner@easyenclave.iam.gserviceaccount.com' }}
+      - uses: google-github-actions/setup-gcloud@v2
 
-      # ── Create staging image ─────────────────────────────────────
-      - name: Create GCP image
+      - name: PR integration test
         env:
-          GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
-          GCS_BUCKET: ${{ secrets.GCS_BUCKET }}
           SHA12: ${{ needs.build.outputs.sha12 }}
-          GCP_NAME: ${{ needs.build.outputs.gcp_name }}
-          IS_PR: ${{ github.event_name == 'pull_request' }}
+          ASSET_BASE: ${{ needs.build.outputs.asset_base }}
+          TEST_GCP_PROJECT_VAR: ${{ vars.TEST_GCP_PROJECT_ID }}
+          TEST_GCP_PROJECT_SECRET: ${{ secrets.GCP_PROJECT_ID }}
+          TEST_GCS_BUCKET_VAR: ${{ vars.TEST_GCS_BUCKET }}
+          TEST_GCS_BUCKET_SECRET: ${{ secrets.GCS_BUCKET }}
+          TEST_ZONE_VAR: ${{ vars.TEST_ZONE }}
+          TEST_MACHINE_TYPE_VAR: ${{ vars.TEST_MACHINE_TYPE }}
+          PR_TEST_EE_CONFIG_JSON_VAR: ${{ vars.PR_TEST_EE_CONFIG_JSON }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SMOKE_ADMIN_IMAGE: ${{ needs.publish-smoke-admin-image.outputs.image_ref }}
         run: |
-          ASSET_BASE="easyenclave-${SHA12}"
-          gcloud storage cp "image/output/${ASSET_BASE}-gcp.tar.gz" \
-            "gs://${GCS_BUCKET}/${ASSET_BASE}-gcp.tar.gz"
+          TEST_GCP_PROJECT="${TEST_GCP_PROJECT_VAR:-${TEST_GCP_PROJECT_SECRET}}"
+          TEST_GCS_BUCKET="${TEST_GCS_BUCKET_VAR:-${TEST_GCS_BUCKET_SECRET}}"
+          TEST_ZONE="${TEST_ZONE_VAR:-us-central1-c}"
+          TEST_MACHINE_TYPE="${TEST_MACHINE_TYPE_VAR:-c3-standard-4}"
+          CONFIG_JSON="${PR_TEST_EE_CONFIG_JSON_VAR:-}"
 
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            FAMILY="--family=easyenclave-stable"
-            CHANNEL="stable"
-          elif [ "$IS_PR" = "true" ]; then
-            FAMILY="--family=easyenclave-staging"
-            CHANNEL="pr"
-          else
-            FAMILY="--family=easyenclave-staging"
-            CHANNEL="staging"
+          if [[ -z "$CONFIG_JSON" ]]; then
+            CONFIG_JSON=$(python - <<'PY'
+          import json
+          import os
+
+          payload = {
+              "EE_OWNER": "pr-integration-test",
+              "EE_BOOT_WORKLOADS": json.dumps(
+                  [
+                      {
+                          "image": os.environ["SMOKE_ADMIN_IMAGE"],
+                          "app_name": "smoke-admin",
+                          "native": True,
+                          "env": [
+                              "EE_SMOKE_ADMIN_PORT=8080",
+                              "EE_SMOKE_ADMIN_TITLE=EasyEnclave PR Smoke Admin",
+                          ],
+                      }
+                  ]
+              ),
+          }
+          print(json.dumps(payload))
+          PY
+            )
           fi
 
-          gcloud compute images create "${GCP_NAME}" \
-            --project="${GCP_PROJECT}" \
-            --source-uri="gs://${GCS_BUCKET}/${ASSET_BASE}-gcp.tar.gz" \
-            ${FAMILY} \
-            --guest-os-features=UEFI_COMPATIBLE,TDX_CAPABLE,GVNIC \
-            --labels=easyenclave=image,channel=${CHANNEL},commit=${SHA12}
-          echo "Created: ${GCP_NAME} (${CHANNEL})"
+          python .github/scripts/write_ee_config.py \
+            --json "$CONFIG_JSON" \
+            --output /tmp/pr-ee-config.json \
+            --require-native-static
 
-      # ── Integration test ─────────────────────────────────────────
-      - name: Integration test — deploy workload + curl HTTP
-        env:
-          GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
-          GCP_NAME: ${{ needs.build.outputs.gcp_name }}
-          SHA12: ${{ needs.build.outputs.sha12 }}
-        run: |
-          LABEL="${SHA12}"
-          CHECKS=(
-            "kernel_boot:Run /init as init process:1"
-            "root_resolved:Resolved root to /dev/:1"
-            "easyenclave_pid1:easyenclave: running as PID 1:1"
-            "tmpfs_mounted:mounted /var/lib/easyenclave:1"
-            "cgroup_mounted:mounted /sys/fs/cgroup:1"
-            "tdx_attestation:attestation backend: tdx:1"
-            "network_up:Device link is up:1"
-            "dhcp_lease:lease of .* obtained:1"
-            "dns_configured:dns from dhcp lease:1"
-            "gce_metadata:gce-meta env:1"
-            "listening:easyenclave: listening on:1"
-            "container_started:container .* started:1"
-            "deployment_running:deployment .* running:1"
-          )
-
-          cat > /tmp/ee-config.json <<'EECONF'
-          {
-            "EE_OWNER": "integration-test",
-            "EE_BOOT_WORKLOADS": "[{\"image\":\"docker.io/traefik/whoami:latest\",\"app_name\":\"whoami\",\"env\":[]}]"
-          }
-          EECONF
-
-          gcloud compute firewall-rules describe ee-smoke-allow-http \
-            --project="$GCP_PROJECT" >/dev/null 2>&1 || \
-          gcloud compute firewall-rules create ee-smoke-allow-http \
-            --project="$GCP_PROJECT" --allow=tcp:80 \
-            --target-tags=ee-smoke-test --source-ranges=0.0.0.0/0 --quiet
-
-          VM_NAME="ee-test-$(date +%s)"
-          gcloud compute instances create "$VM_NAME" \
-            --project="$GCP_PROJECT" --zone=us-central1-c \
-            --machine-type=c3-standard-4 \
-            --confidential-compute-type=TDX --maintenance-policy=TERMINATE \
-            --image="${GCP_NAME}" --image-project="$GCP_PROJECT" \
-            --boot-disk-size=10GB \
-            --metadata-from-file=ee-config=/tmp/ee-config.json \
-            --tags=ee-smoke-test
+          GCS_OBJECT="gs://${TEST_GCS_BUCKET}/pr/${PR_NUMBER}/${ASSET_BASE}-gcp.tar.gz"
+          IMAGE_NAME="easyenclave-pr-${PR_NUMBER}-${SHA12}"
 
           cleanup() {
-            gcloud compute instances delete "$VM_NAME" \
-              --project="$GCP_PROJECT" --zone=us-central1-c --quiet || true
+            gcloud compute images delete "$IMAGE_NAME" \
+              --project="$TEST_GCP_PROJECT" --quiet >/dev/null 2>&1 || true
+            gcloud storage rm "$GCS_OBJECT" >/dev/null 2>&1 || true
           }
+          trap cleanup EXIT
 
-          declare -A PASSED
-          LAST_LINES=0
-          ALL_REQUIRED_DONE=false
+          gcloud storage cp "image/output/${ASSET_BASE}-gcp.tar.gz" "$GCS_OBJECT"
 
-          for i in $(seq 1 36); do
-            out=$(gcloud compute instances get-serial-port-output "$VM_NAME" \
-              --project="$GCP_PROJECT" --zone=us-central1-c 2>/dev/null || true)
-            TOTAL_LINES=$(echo "$out" | wc -l)
-            if [ "$TOTAL_LINES" -gt "$LAST_LINES" ]; then
-              echo "$out" | tail -n +$((LAST_LINES + 1)) | sed 's/^/[serial] /'
-              LAST_LINES=$TOTAL_LINES
-            fi
-            if echo "$out" | grep -qE "FATAL|Kernel panic|switch_root: can|Invalid ELF header"; then
-              echo "::error::boot failed — fatal pattern in serial"
-              break
-            fi
-            for check in "${CHECKS[@]}"; do
-              IFS=: read -r name pattern required <<< "$check"
-              [ -n "${PASSED[$name]:-}" ] && continue
-              echo "$out" | grep -qE "$pattern" && PASSED[$name]=1 && echo "  ✓ $name"
-            done
-            ALL_REQUIRED_DONE=true
-            for check in "${CHECKS[@]}"; do
-              IFS=: read -r name pattern required <<< "$check"
-              [ "$required" = "0" ] && continue
-              [ -z "${PASSED[$name]:-}" ] && ALL_REQUIRED_DONE=false && break
-            done
-            $ALL_REQUIRED_DONE && break
-            echo "  waiting... (${i}/36)"
-            sleep 10
-          done
+          gcloud compute images create "$IMAGE_NAME" \
+            --project="$TEST_GCP_PROJECT" \
+            --source-uri="$GCS_OBJECT" \
+            --guest-os-features=UEFI_COMPATIBLE,TDX_CAPABLE,GVNIC \
+            --labels=easyenclave=image,channel=pr,commit="${SHA12}"
 
-          HTTP_OK=false
-          if $ALL_REQUIRED_DONE; then
-            VM_IP=$(gcloud compute instances describe "$VM_NAME" \
-              --project="$GCP_PROJECT" --zone=us-central1-c \
-              --format="value(networkInterfaces[0].accessConfigs[0].natIP)")
-            echo ""
-            echo "Testing HTTP on $VM_IP:80..."
-            for i in $(seq 1 12); do
-              code=$(curl -sS -o /dev/null -w '%{http_code}' \
-                --connect-timeout 5 "http://$VM_IP:80/" 2>/dev/null || echo 000)
-              [ "$code" = "200" ] && echo "  ✓ workload_http ($VM_IP)" && HTTP_OK=true && break
-              echo "  waiting... ${code} (${i}/12)"
-              sleep 5
-            done
-          fi
+          bash .github/scripts/smoke_test_gcp_vm.sh \
+            --project "$TEST_GCP_PROJECT" \
+            --zone "$TEST_ZONE" \
+            --machine-type "$TEST_MACHINE_TYPE" \
+            --image "$IMAGE_NAME" \
+            --image-project "$TEST_GCP_PROJECT" \
+            --metadata-file /tmp/pr-ee-config.json \
+            --mode native-static \
+            --http-port 8080 \
+            --http-path /health
 
-          echo ""
-          echo "=== integration test (${LABEL}) ==="
-          PASS=0; TOTAL=0
-          for check in "${CHECKS[@]}"; do
-            IFS=: read -r name pattern required <<< "$check"
-            [ "$required" = "1" ] && TOTAL=$((TOTAL + 1))
-            if [ -n "${PASSED[$name]:-}" ]; then
-              echo "  ✓ $name"
-              [ "$required" = "1" ] && PASS=$((PASS + 1))
-            else
-              echo "  ✗ $name"
-            fi
-          done
-          TOTAL=$((TOTAL + 1))
-          $HTTP_OK && echo "  ✓ workload_http" && PASS=$((PASS + 1)) || echo "  ✗ workload_http"
-          echo "${PASS}/${TOTAL} passed"
+  release-candidate-test:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs:
+      - build
+      - publish-smoke-admin-image
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: actions/download-artifact@v4
+        with:
+          name: easyenclave-image
+          path: image/output
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER || 'projects/779946350556/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider' }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT || 'easyenclave-github-provisioner@easyenclave.iam.gserviceaccount.com' }}
+      - uses: google-github-actions/setup-gcloud@v2
 
-          if $ALL_REQUIRED_DONE && $HTTP_OK; then
-            echo "✓ Integration test passed"
-            cleanup; exit 0
-          else
-            echo "::error::Integration test failed (${PASS}/${TOTAL})"
-            echo "$out" | tail -80
-            cleanup; exit 1
-          fi
-
-      # ── Release (merge/tag only) ─────────────────────────────────
-      - name: Rotate old images
-        if: github.event_name != 'pull_request'
+      - name: Release candidate smoke test
         env:
-          GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
-        run: |
-          for filter in "labels.channel=staging" "labels.channel=pr"; do
-            KEEP=$( [ "$filter" = "labels.channel=pr" ] && echo 11 || echo 6 )
-            gcloud compute images list --project="${GCP_PROJECT}" \
-              --filter="labels.easyenclave=image AND ${filter}" \
-              --format="value(name)" --sort-by="~creationTimestamp" \
-              | tail -n +${KEEP} \
-              | xargs -rI{} gcloud compute images delete {} \
-                  --project="${GCP_PROJECT}" --quiet
-          done
-
-      - name: Create GitHub Release
-        if: github.event_name != 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
-          GCP_NAME: ${{ needs.build.outputs.gcp_name }}
           SHA12: ${{ needs.build.outputs.sha12 }}
-          UKI_SHA256: ${{ needs.build.outputs.uki_sha256 }}
+          ASSET_BASE: ${{ needs.build.outputs.asset_base }}
+          RELEASE_GCP_PROJECT_VAR: ${{ vars.RELEASE_GCP_PROJECT_ID }}
+          FALLBACK_GCP_PROJECT_SECRET: ${{ secrets.GCP_PROJECT_ID }}
+          RELEASE_GCS_BUCKET_VAR: ${{ vars.RELEASE_GCS_BUCKET }}
+          RELEASE_IMAGE_PREFIX_VAR: ${{ vars.RELEASE_IMAGE_PREFIX }}
+          RELEASE_TEST_EE_CONFIG_JSON_VAR: ${{ vars.RELEASE_TEST_EE_CONFIG_JSON }}
+          RELEASE_TEST_INPUT_JSON: ${{ inputs.release_test_config_json }}
+          RELEASE_ZONE_VAR: ${{ vars.RELEASE_ZONE }}
+          RELEASE_MACHINE_TYPE_VAR: ${{ vars.RELEASE_MACHINE_TYPE }}
+          FALLBACK_GCS_BUCKET_SECRET: ${{ secrets.GCS_BUCKET }}
+          SMOKE_ADMIN_IMAGE: ${{ needs.publish-smoke-admin-image.outputs.image_ref }}
         run: |
-          cd image/output
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            TAG="${GITHUB_REF#refs/tags/}"
-            GH_TAG="${TAG}"
-            ASSET_BASE="easyenclave-${TAG}"
-            PRERELEASE=""
-            for ext in efi raw qcow2; do
-              mv "easyenclave-${SHA12}.${ext}" "${ASSET_BASE}.${ext}"
-            done
-            mv "easyenclave-${SHA12}-gcp.tar.gz" "${ASSET_BASE}-gcp.tar.gz"
-          else
-            GH_TAG="image-${SHA12}"
-            ASSET_BASE="easyenclave-${SHA12}"
-            PRERELEASE="--prerelease"
+          RELEASE_GCP_PROJECT="${RELEASE_GCP_PROJECT_VAR:-${FALLBACK_GCP_PROJECT_SECRET}}"
+          RELEASE_GCS_BUCKET="${RELEASE_GCS_BUCKET_VAR:-${FALLBACK_GCS_BUCKET_SECRET}}"
+          RELEASE_ZONE="${RELEASE_ZONE_VAR:-us-central1-c}"
+          RELEASE_MACHINE_TYPE="${RELEASE_MACHINE_TYPE_VAR:-c3-standard-4}"
+          RELEASE_IMAGE_PREFIX="${RELEASE_IMAGE_PREFIX_VAR:-easyenclave-release}"
+          CONFIG_JSON="${RELEASE_TEST_INPUT_JSON:-${RELEASE_TEST_EE_CONFIG_JSON_VAR:-}}"
+
+          if [[ -z "$CONFIG_JSON" ]]; then
+            CONFIG_JSON=$(python - <<'PY'
+          import json
+          import os
+
+          payload = {
+              "EE_OWNER": "release-smoke-test",
+              "EE_BOOT_WORKLOADS": json.dumps(
+                  [
+                      {
+                          "image": os.environ["SMOKE_ADMIN_IMAGE"],
+                          "app_name": "smoke-admin",
+                          "native": True,
+                          "env": [
+                              "EE_SMOKE_ADMIN_PORT=8080",
+                              "EE_SMOKE_ADMIN_TITLE=EasyEnclave Release Smoke Admin",
+                          ],
+                      }
+                  ]
+              ),
+          }
+          print(json.dumps(payload))
+          PY
+            )
           fi
-          gh release create "${GH_TAG}" ${PRERELEASE} \
-            --title "${GH_TAG}" \
-            --notes "UKI SHA256: \`${UKI_SHA256}\`
-          GCP image: \`${GCP_NAME}\`" \
-            "${ASSET_BASE}.efi" "${ASSET_BASE}.raw" \
-            "${ASSET_BASE}.qcow2" "${ASSET_BASE}-gcp.tar.gz" \
-            "MEASUREMENTS.txt"
+
+          python .github/scripts/write_ee_config.py \
+            --json "$CONFIG_JSON" \
+            --output /tmp/release-ee-config.json \
+            --require-native-static
+
+          GCS_OBJECT="gs://${RELEASE_GCS_BUCKET}/release/${ASSET_BASE}-gcp.tar.gz"
+          CANDIDATE_IMAGE="${RELEASE_IMAGE_PREFIX}-${SHA12}-candidate"
+
+          cleanup() {
+            gcloud compute images delete "$CANDIDATE_IMAGE" \
+              --project="$RELEASE_GCP_PROJECT" --quiet >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          gcloud storage cp "image/output/${ASSET_BASE}-gcp.tar.gz" "$GCS_OBJECT"
+
+          gcloud compute images create "$CANDIDATE_IMAGE" \
+            --project="$RELEASE_GCP_PROJECT" \
+            --source-uri="$GCS_OBJECT" \
+            --guest-os-features=UEFI_COMPATIBLE,TDX_CAPABLE,GVNIC \
+            --labels=easyenclave=image,channel=release-candidate,commit="${SHA12}"
+
+          bash .github/scripts/smoke_test_gcp_vm.sh \
+            --project "$RELEASE_GCP_PROJECT" \
+            --zone "$RELEASE_ZONE" \
+            --machine-type "$RELEASE_MACHINE_TYPE" \
+            --image "$CANDIDATE_IMAGE" \
+            --image-project "$RELEASE_GCP_PROJECT" \
+            --metadata-file /tmp/release-ee-config.json \
+            --mode native-static \
+            --http-port 8080 \
+            --http-path /health
+
+  publish-release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs:
+      - build
+      - release-candidate-test
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER || 'projects/779946350556/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider' }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT || 'easyenclave-github-provisioner@easyenclave.iam.gserviceaccount.com' }}
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Publish verified release image
+        env:
+          SHA12: ${{ needs.build.outputs.sha12 }}
+          ASSET_BASE: ${{ needs.build.outputs.asset_base }}
+          RELEASE_GCP_PROJECT_VAR: ${{ vars.RELEASE_GCP_PROJECT_ID }}
+          FALLBACK_GCP_PROJECT_SECRET: ${{ secrets.GCP_PROJECT_ID }}
+          RELEASE_GCS_BUCKET_VAR: ${{ vars.RELEASE_GCS_BUCKET }}
+          RELEASE_IMAGE_PREFIX_VAR: ${{ vars.RELEASE_IMAGE_PREFIX }}
+          RELEASE_IMAGE_FAMILY_VAR: ${{ vars.RELEASE_IMAGE_FAMILY }}
+          FALLBACK_GCS_BUCKET_SECRET: ${{ secrets.GCS_BUCKET }}
+        run: |
+          RELEASE_GCP_PROJECT="${RELEASE_GCP_PROJECT_VAR:-${FALLBACK_GCP_PROJECT_SECRET}}"
+          RELEASE_GCS_BUCKET="${RELEASE_GCS_BUCKET_VAR:-${FALLBACK_GCS_BUCKET_SECRET}}"
+          RELEASE_IMAGE_PREFIX="${RELEASE_IMAGE_PREFIX_VAR:-easyenclave-release}"
+          RELEASE_IMAGE_FAMILY="${RELEASE_IMAGE_FAMILY_VAR:-easyenclave-release}"
+          GCS_OBJECT="gs://${RELEASE_GCS_BUCKET}/release/${ASSET_BASE}-gcp.tar.gz"
+          FINAL_IMAGE="${RELEASE_IMAGE_PREFIX}-${SHA12}"
+
+          gcloud compute images create "$FINAL_IMAGE" \
+            --project="$RELEASE_GCP_PROJECT" \
+            --source-uri="$GCS_OBJECT" \
+            --family="$RELEASE_IMAGE_FAMILY" \
+            --guest-os-features=UEFI_COMPATIBLE,TDX_CAPABLE,GVNIC \
+            --labels=easyenclave=image,channel=release,commit="${SHA12}"
+
+          gcloud compute images list --project="$RELEASE_GCP_PROJECT" \
+            --filter="labels.easyenclave=image AND labels.channel=release" \
+            --format="value(name)" \
+            --sort-by="~creationTimestamp" \
+            | tail -n +11 \
+            | xargs -rI{} gcloud compute images delete {} \
+                --project="$RELEASE_GCP_PROJECT" --quiet

--- a/Dockerfile.smoke-admin
+++ b/Dockerfile.smoke-admin
@@ -1,0 +1,13 @@
+FROM rust:1-bookworm AS builder
+RUN rustup target add x86_64-unknown-linux-musl && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends musl-tools && \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+COPY . .
+RUN cargo build --release --target x86_64-unknown-linux-musl --bin ee-smoke-admin
+
+FROM scratch
+COPY --from=builder /src/target/x86_64-unknown-linux-musl/release/ee-smoke-admin /ee-smoke-admin
+EXPOSE 8080
+ENTRYPOINT ["/ee-smoke-admin"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Generic enclave runtime for Intel TDX confidential VMs. Runs as PID 1 inside a sealed VM and exposes a unix socket API for workload management.
 
-No HTTP server. No networking. No database. Minimal attack surface.
+No HTTP server. Unix socket control plane only. No database. Minimal attack surface.
+
+`native` deployments are intentionally narrow: easyenclave extracts and runs a single static ELF from the OCI image rather than unpacking a full root filesystem.
 
 ## Quick start
 
@@ -24,6 +26,8 @@ TDX VM (hardware-sealed memory)
         └── TDX attestation (configfs-tsm)
 ```
 
+The control API is local-only over a Unix socket, but the runtime does configure guest networking at boot and can use outbound HTTP(S) for DHCP-dependent metadata fetches and OCI image pulls.
+
 ## Socket API
 
 Newline-delimited JSON over `/var/lib/easyenclave/agent.sock`:
@@ -32,11 +36,11 @@ Newline-delimited JSON over `/var/lib/easyenclave/agent.sock`:
 |--------|---------|----------|
 | health | `{"method":"health"}` | `{"ok":true,"attestation_type":"tdx","workloads":2}` |
 | deploy | `{"method":"deploy","image":"...","app_name":"myapp"}` | `{"ok":true,"id":"...","status":"deploying"}` |
-| attest | `{"method":"attest","nonce":"..."}` | `{"ok":true,"quote_b64":"..."}` |
+| attest | `{"method":"attest","nonce":"<base64>"}` | `{"ok":true,"quote_b64":"..."}` |
 | list | `{"method":"list"}` | `{"ok":true,"deployments":[...]}` |
 | stop | `{"method":"stop","id":"..."}` | `{"ok":true}` |
 | exec | `{"method":"exec","cmd":["uname","-a"]}` | `{"ok":true,"exit_code":0,"stdout":"..."}` |
-| logs | `{"method":"logs","id":"..."}` | `{"ok":true,"logs":["..."]}` |
+| logs | `{"method":"logs","id":"..."}` | `{"ok":true,"lines":["..."]}` |
 
 ## Configuration
 

--- a/image/mkinitrd.sh
+++ b/image/mkinitrd.sh
@@ -27,7 +27,7 @@ fi
 chmod +x "$WORKDIR/bin/busybox"
 
 # Symlink essential commands
-for cmd in sh mount umount switch_root mkdir cat echo sleep modprobe insmod findfs ls; do
+for cmd in sh mount umount switch_root mkdir cat echo sleep modprobe insmod findfs ls seq; do
     ln -s busybox "$WORKDIR/bin/$cmd"
 done
 

--- a/image/mkosi.conf
+++ b/image/mkosi.conf
@@ -1,6 +1,7 @@
 # EasyEnclave TDX VM Image
 #
-# Minimal sealed image: easyenclave as PID 1, dm-verity protected rootfs.
+# Minimal sealed image: easyenclave as PID 1, with support for an optional
+# dm-verity protected rootfs.
 # No systemd, no SSH, no login shell, no podman, no docker, no
 # bootloader. Easyenclave has its own Rust-native container runtime
 # compiled into the binary (libcontainer + oci-distribution), so the

--- a/image/test-local.sh
+++ b/image/test-local.sh
@@ -35,7 +35,7 @@ command -v qemu-system-x86_64 >/dev/null || { echo "qemu-system-x86_64 not found
 TDX_SUPPORT=$(cat /sys/module/kvm_intel/parameters/tdx 2>/dev/null || echo "N")
 if [ "$TDX_SUPPORT" != "Y" ]; then
     echo "WARNING: TDX not available on this host (kvm_intel.tdx=$TDX_SUPPORT)"
-    echo "         Booting without TDX — attestation will fail but everything else works."
+    echo "         Booting without TDX — easyenclave will reach attestation detection and then exit."
     TDX_FLAGS=""
 else
     TDX_FLAGS="-machine q35,kernel-irqchip=split,confidential-guest-support=tdx -object tdx-guest,id=tdx"
@@ -47,12 +47,14 @@ if [ -n "$ENV_FILE" ]; then
     [ -f "$ENV_FILE" ] || { echo "agent.env not found: $ENV_FILE"; exit 1; }
     command -v genisoimage >/dev/null || { echo "genisoimage not found (apt install genisoimage)"; exit 1; }
 
+    CONFIG_DIR=$(mktemp -d)
     CONFIG_ISO=$(mktemp --suffix=.iso)
-    trap 'rm -f "$CONFIG_ISO"' EXIT
+    trap 'rm -rf "$CONFIG_DIR" "$CONFIG_ISO"' EXIT
 
-    genisoimage -quiet -o "$CONFIG_ISO" -V CONFIG -r -J "$ENV_FILE"
+    cp "$ENV_FILE" "$CONFIG_DIR/agent.env"
+    genisoimage -quiet -o "$CONFIG_ISO" -V CONFIG -r -J "$CONFIG_DIR/agent.env"
     CONFIG_DRIVE="-drive file=$CONFIG_ISO,if=virtio,format=raw,media=cdrom,readonly=on"
-    echo "Config ISO: $CONFIG_ISO (from $ENV_FILE)"
+    echo "Config ISO: $CONFIG_ISO (from $ENV_FILE, staged as /agent.env)"
 fi
 
 # ── Boot ─────────────────────────────────────────────────────────────

--- a/src/attestation/tsm.rs
+++ b/src/attestation/tsm.rs
@@ -15,9 +15,7 @@ fn generate_tdx_quote(report_root: &str, user_data: &[u8]) -> Result<Vec<u8>, St
     let root = Path::new(report_root);
 
     // Pad or truncate user data to exactly 64 bytes (configfs-tsm requirement).
-    let mut padded = [0u8; 64];
-    let copy_len = user_data.len().min(64);
-    padded[..copy_len].copy_from_slice(&user_data[..copy_len]);
+    let padded = normalize_report_data(user_data);
 
     // Write raw binary user data to the inblob file.
     let inblob_path = root.join("inblob");
@@ -36,12 +34,17 @@ fn generate_tdx_quote_base64(user_data: &[u8]) -> Result<String, String> {
 
     std::fs::create_dir_all(&report_root).map_err(|e| format!("create tsm report dir: {e}"))?;
 
-    let quote_bytes = generate_tdx_quote(&report_root, user_data)?;
-
-    // Clean up.
+    let result = generate_tdx_quote(&report_root, user_data)
+        .map(|quote_bytes| base64::engine::general_purpose::STANDARD.encode(&quote_bytes));
     let _ = std::fs::remove_dir_all(&report_root);
+    result
+}
 
-    Ok(base64::engine::general_purpose::STANDARD.encode(&quote_bytes))
+fn normalize_report_data(user_data: &[u8]) -> [u8; 64] {
+    let mut padded = [0u8; 64];
+    let copy_len = user_data.len().min(64);
+    padded[..copy_len].copy_from_slice(&user_data[..copy_len]);
+    padded
 }
 
 /// TDX attestation backend using configfs-tsm.
@@ -58,5 +61,25 @@ impl super::AttestationBackend for TdxBackend {
 
     fn generate_quote_with_nonce(&self, nonce: &[u8]) -> Option<String> {
         generate_tdx_quote_base64(nonce).ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_report_data;
+
+    #[test]
+    fn normalize_report_data_pads_short_input() {
+        let data = normalize_report_data(b"abc");
+        assert_eq!(&data[..3], b"abc");
+        assert!(data[3..].iter().all(|b| *b == 0));
+    }
+
+    #[test]
+    fn normalize_report_data_truncates_long_input() {
+        let input = vec![7u8; 80];
+        let data = normalize_report_data(&input);
+        assert_eq!(data.len(), 64);
+        assert!(data.iter().all(|b| *b == 7));
     }
 }

--- a/src/bin/ee-smoke-admin.rs
+++ b/src/bin/ee-smoke-admin.rs
@@ -1,0 +1,437 @@
+use serde_json::{json, Value};
+use std::env;
+use std::io::{BufRead, BufReader, Write};
+use std::net::{TcpListener, TcpStream};
+use std::os::unix::net::UnixStream;
+use std::time::Duration;
+
+const DEFAULT_HOST: &str = "0.0.0.0";
+const DEFAULT_PORT: u16 = 8080;
+const DEFAULT_SOCKET_PATH: &str = "/var/lib/easyenclave/agent.sock";
+const DEFAULT_TITLE: &str = "EasyEnclave Smoke Admin";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Config {
+    host: String,
+    port: u16,
+    socket_path: String,
+    title: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct RequestLine {
+    method: String,
+    path: String,
+}
+
+fn main() {
+    let config = Config::from_env();
+    let addr = format!("{}:{}", config.host, config.port);
+
+    let listener = TcpListener::bind(&addr).unwrap_or_else(|e| {
+        eprintln!("ee-smoke-admin: bind failed on {addr}: {e}");
+        std::process::exit(1);
+    });
+    eprintln!("ee-smoke-admin: listening on http://{addr}");
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                let config = config.clone();
+                std::thread::spawn(move || {
+                    if let Err(err) = handle_connection(stream, &config) {
+                        eprintln!("ee-smoke-admin: request error: {err}");
+                    }
+                });
+            }
+            Err(err) => eprintln!("ee-smoke-admin: accept failed: {err}"),
+        }
+    }
+}
+
+impl Config {
+    fn from_env() -> Self {
+        Self {
+            host: env::var("EE_SMOKE_ADMIN_HOST").unwrap_or_else(|_| DEFAULT_HOST.to_string()),
+            port: env::var("EE_SMOKE_ADMIN_PORT")
+                .ok()
+                .and_then(|raw| raw.parse().ok())
+                .unwrap_or(DEFAULT_PORT),
+            socket_path: env::var("EE_SOCKET_PATH")
+                .unwrap_or_else(|_| DEFAULT_SOCKET_PATH.to_string()),
+            title: env::var("EE_SMOKE_ADMIN_TITLE").unwrap_or_else(|_| DEFAULT_TITLE.to_string()),
+        }
+    }
+}
+
+fn handle_connection(mut stream: TcpStream, config: &Config) -> Result<(), String> {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .map_err(|e| format!("set read timeout: {e}"))?;
+    stream
+        .set_write_timeout(Some(Duration::from_secs(5)))
+        .map_err(|e| format!("set write timeout: {e}"))?;
+
+    let mut reader = BufReader::new(
+        stream
+            .try_clone()
+            .map_err(|e| format!("clone stream: {e}"))?,
+    );
+    let mut request_line = String::new();
+    let bytes = reader
+        .read_line(&mut request_line)
+        .map_err(|e| format!("read request line: {e}"))?;
+    if bytes == 0 || request_line.trim().is_empty() {
+        return Ok(());
+    }
+
+    loop {
+        let mut header = String::new();
+        let bytes = reader
+            .read_line(&mut header)
+            .map_err(|e| format!("read header: {e}"))?;
+        if bytes == 0 || header == "\r\n" {
+            break;
+        }
+    }
+
+    let request = parse_request_line(&request_line)?;
+    let response = route_request(&request, config);
+    stream
+        .write_all(response.as_bytes())
+        .map_err(|e| format!("write response: {e}"))?;
+    Ok(())
+}
+
+fn parse_request_line(raw: &str) -> Result<RequestLine, String> {
+    let mut parts = raw.split_whitespace();
+    let method = parts
+        .next()
+        .ok_or_else(|| "missing method".to_string())?
+        .to_string();
+    let target = parts.next().ok_or_else(|| "missing path".to_string())?;
+    let _version = parts.next().ok_or_else(|| "missing version".to_string())?;
+    if parts.next().is_some() {
+        return Err("malformed request line".into());
+    }
+
+    Ok(RequestLine {
+        method,
+        path: target.split('?').next().unwrap_or(target).to_string(),
+    })
+}
+
+fn route_request(request: &RequestLine, config: &Config) -> String {
+    if request.method != "GET" {
+        return text_response(405, "method not allowed\n");
+    }
+
+    match request.path.as_str() {
+        "/" => root_response(config),
+        "/health" => health_response(config),
+        "/deployments" => deployments_response(config),
+        _ => text_response(404, "not found\n"),
+    }
+}
+
+fn root_response(config: &Config) -> String {
+    let health = match ee_ok_response(&config.socket_path, json!({"method": "health"})) {
+        Ok(value) => value,
+        Err(err) => {
+            return html_response(
+                503,
+                &format!(
+                    "<!doctype html><title>{}</title><h1>{}</h1><p>easyenclave unavailable: {}</p>",
+                    escape_html(&config.title),
+                    escape_html(&config.title),
+                    escape_html(&err),
+                ),
+            )
+        }
+    };
+
+    let deployments = match ee_ok_response(&config.socket_path, json!({"method": "list"})) {
+        Ok(value) => value,
+        Err(err) => {
+            return html_response(
+                503,
+                &format!(
+                    "<!doctype html><title>{}</title><h1>{}</h1><p>deployment query failed: {}</p>",
+                    escape_html(&config.title),
+                    escape_html(&config.title),
+                    escape_html(&err),
+                ),
+            )
+        }
+    };
+
+    let health_pretty =
+        serde_json::to_string_pretty(&health).unwrap_or_else(|_| "{\"ok\":false}".to_string());
+
+    let rows = deployments["deployments"]
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .map(|deployment| {
+                    let app_name = deployment["app_name"].as_str().unwrap_or("unknown");
+                    let status = deployment["status"].as_str().unwrap_or("unknown");
+                    let image = deployment["image"].as_str().unwrap_or("");
+                    format!(
+                        "<tr><td>{}</td><td>{}</td><td>{}</td></tr>",
+                        escape_html(app_name),
+                        escape_html(status),
+                        escape_html(image),
+                    )
+                })
+                .collect::<String>()
+        })
+        .filter(|rows| !rows.is_empty())
+        .unwrap_or_else(|| {
+            "<tr><td colspan=\"3\">No deployments reported by easyenclave</td></tr>".to_string()
+        });
+
+    let body = format!(
+        concat!(
+            "<!doctype html><html><head><meta charset=\"utf-8\">",
+            "<title>{title}</title>",
+            "<style>",
+            "body{{font-family:ui-sans-serif,system-ui,sans-serif;max-width:920px;margin:2rem auto;padding:0 1rem;color:#172033;}}",
+            "h1{{margin-bottom:.25rem;}}",
+            ".sub{{color:#4b5563;margin-bottom:1.5rem;}}",
+            ".grid{{display:grid;gap:1rem;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));}}",
+            ".card{{border:1px solid #d6deeb;border-radius:12px;padding:1rem;background:#fbfcfe;}}",
+            "pre{{white-space:pre-wrap;word-break:break-word;margin:0;}}",
+            "table{{width:100%;border-collapse:collapse;}}",
+            "th,td{{padding:.6rem;border-bottom:1px solid #e5e7eb;text-align:left;vertical-align:top;}}",
+            "</style></head><body>",
+            "<h1>{title}</h1>",
+            "<div class=\"sub\">Public native smoke-admin for EasyEnclave integration tests</div>",
+            "<div class=\"grid\">",
+            "<section class=\"card\"><h2>Health</h2><pre>{health}</pre></section>",
+            "<section class=\"card\"><h2>Deployments</h2><table><thead><tr><th>app</th><th>status</th><th>image</th></tr></thead><tbody>{rows}</tbody></table></section>",
+            "</div></body></html>"
+        ),
+        title = escape_html(&config.title),
+        health = escape_html(&health_pretty),
+        rows = rows,
+    );
+
+    html_response(200, &body)
+}
+
+fn health_response(config: &Config) -> String {
+    match ee_ok_response(&config.socket_path, json!({"method": "health"})) {
+        Ok(health) => json_response(
+            200,
+            &json!({
+                "ok": true,
+                "service": "ee-smoke-admin",
+                "easyenclave": health,
+            }),
+        ),
+        Err(err) => json_response(
+            503,
+            &json!({
+                "ok": false,
+                "service": "ee-smoke-admin",
+                "error": err,
+            }),
+        ),
+    }
+}
+
+fn deployments_response(config: &Config) -> String {
+    match ee_ok_response(&config.socket_path, json!({"method": "list"})) {
+        Ok(deployments) => json_response(200, &deployments),
+        Err(err) => json_response(503, &json!({"ok": false, "error": err})),
+    }
+}
+
+fn ee_ok_response(socket_path: &str, request: Value) -> Result<Value, String> {
+    let response = ee_request(socket_path, request)?;
+    if response["ok"].as_bool() == Some(true) {
+        Ok(response)
+    } else {
+        Err(response["error"]
+            .as_str()
+            .unwrap_or("easyenclave returned an unknown error")
+            .to_string())
+    }
+}
+
+fn ee_request(socket_path: &str, request: Value) -> Result<Value, String> {
+    let mut stream =
+        UnixStream::connect(socket_path).map_err(|e| format!("connect {socket_path}: {e}"))?;
+    configure_socket_timeouts(&stream)?;
+    ee_request_over_io(&mut stream, request)
+}
+
+fn ee_request_over_io<T: std::io::Read + std::io::Write>(
+    stream: &mut T,
+    request: Value,
+) -> Result<Value, String> {
+    let payload = serde_json::to_string(&request).map_err(|e| format!("serialize request: {e}"))?;
+    stream
+        .write_all(payload.as_bytes())
+        .and_then(|_| stream.write_all(b"\n"))
+        .map_err(|e| format!("write socket request: {e}"))?;
+
+    let mut reader = BufReader::new(stream);
+    let mut response = String::new();
+    reader
+        .read_line(&mut response)
+        .map_err(|e| format!("read socket response: {e}"))?;
+    if response.trim().is_empty() {
+        return Err("easyenclave returned an empty response".into());
+    }
+
+    serde_json::from_str(response.trim_end()).map_err(|e| format!("parse socket response: {e}"))
+}
+
+fn configure_socket_timeouts(stream: &UnixStream) -> Result<(), String> {
+    for (label, result) in [
+        (
+            "read",
+            stream.set_read_timeout(Some(Duration::from_secs(5))),
+        ),
+        (
+            "write",
+            stream.set_write_timeout(Some(Duration::from_secs(5))),
+        ),
+    ] {
+        if let Err(err) = result {
+            if err.kind() == std::io::ErrorKind::PermissionDenied
+                || err.kind() == std::io::ErrorKind::Unsupported
+            {
+                continue;
+            }
+            return Err(format!("set socket {label} timeout: {err}"));
+        }
+    }
+    Ok(())
+}
+
+fn json_response(status: u16, body: &Value) -> String {
+    let body = serde_json::to_string_pretty(body).unwrap_or_else(|_| "{\"ok\":false}".to_string());
+    http_response(status, "application/json; charset=utf-8", &body)
+}
+
+fn html_response(status: u16, body: &str) -> String {
+    http_response(status, "text/html; charset=utf-8", body)
+}
+
+fn text_response(status: u16, body: &str) -> String {
+    http_response(status, "text/plain; charset=utf-8", body)
+}
+
+fn http_response(status: u16, content_type: &str, body: &str) -> String {
+    format!(
+        "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        status,
+        reason_phrase(status),
+        content_type,
+        body.as_bytes().len(),
+        body
+    )
+}
+
+fn reason_phrase(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        500 => "Internal Server Error",
+        503 => "Service Unavailable",
+        _ => "OK",
+    }
+}
+
+fn escape_html(input: &str) -> String {
+    let mut escaped = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&#39;"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Cursor, Read};
+
+    #[derive(Default)]
+    struct MockStream {
+        read: Cursor<Vec<u8>>,
+        written: Vec<u8>,
+    }
+
+    impl MockStream {
+        fn with_response(response: &str) -> Self {
+            Self {
+                read: Cursor::new(response.as_bytes().to_vec()),
+                written: Vec::new(),
+            }
+        }
+    }
+
+    impl Read for MockStream {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            self.read.read(buf)
+        }
+    }
+
+    impl Write for MockStream {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.written.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn parse_request_line_strips_query_string() {
+        let request = parse_request_line("GET /health?full=1 HTTP/1.1\r\n").unwrap();
+        assert_eq!(
+            request,
+            RequestLine {
+                method: "GET".into(),
+                path: "/health".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn non_get_requests_are_rejected() {
+        let response = route_request(
+            &RequestLine {
+                method: "POST".into(),
+                path: "/health".into(),
+            },
+            &Config::from_env(),
+        );
+        assert!(response.starts_with("HTTP/1.1 405 Method Not Allowed"));
+    }
+
+    #[test]
+    fn ee_request_round_trips_json_over_line_protocol() {
+        let mut stream = MockStream::with_response("{\"ok\":true,\"workloads\":0}\n");
+        let response = ee_request_over_io(&mut stream, json!({"method": "health"})).unwrap();
+        assert_eq!(response["ok"], true);
+        assert_eq!(response["workloads"], 0);
+        assert_eq!(
+            String::from_utf8(stream.written).unwrap(),
+            "{\"method\":\"health\"}\n"
+        );
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,14 @@ const DEFAULT_SOCKET_PATH: &str = "/var/lib/easyenclave/agent.sock";
 const DEFAULT_DATA_DIR: &str = "/var/lib/easyenclave";
 const CONFIG_FILE_PATH: &str = "/etc/easyenclave/config.json";
 
+/// Runtime configuration loaded from disk and environment.
+///
+/// ```
+/// let cfg = easyenclave::config::Config::default();
+/// assert_eq!(cfg.socket_path, "/var/lib/easyenclave/agent.sock");
+/// assert_eq!(cfg.data_dir, "/var/lib/easyenclave");
+/// assert!(cfg.boot_workloads.is_empty());
+/// ```
 #[derive(Debug, Clone, Deserialize)]
 pub struct Config {
     #[serde(default = "default_socket_path")]
@@ -14,6 +22,16 @@ pub struct Config {
     pub data_dir: String,
     #[serde(default)]
     pub boot_workloads: Vec<BootWorkload>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            socket_path: default_socket_path(),
+            data_dir: default_data_dir(),
+            boot_workloads: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -28,9 +46,10 @@ pub struct BootWorkload {
     pub env: Option<Vec<String>>,
     #[serde(default)]
     pub volumes: Option<Vec<String>>,
-    /// Run the OCI image natively (extract binary, exec on host) instead
-    /// of through libcontainer. The binary gets full host access including
-    /// the easyenclave agent socket.
+    /// Run the OCI image natively by extracting a single static ELF
+    /// executable and exec'ing it on the host instead of through
+    /// libcontainer. The binary gets full host access including the
+    /// easyenclave agent socket.
     #[serde(default)]
     pub native: bool,
 }
@@ -47,6 +66,10 @@ fn default_app_name() -> String {
     "unnamed".to_string()
 }
 
+fn parse_boot_workloads_json(raw: &str, source: &str) -> Result<Vec<BootWorkload>, String> {
+    serde_json::from_str::<Vec<BootWorkload>>(raw).map_err(|e| format!("{source} parse error: {e}"))
+}
+
 impl Config {
     /// Load config from file, then overlay with environment variables.
     pub fn load() -> Result<Self, String> {
@@ -56,11 +79,7 @@ impl Config {
                 .map_err(|e| format!("read config: {e}"))?;
             serde_json::from_str::<Config>(&data).map_err(|e| format!("parse config: {e}"))?
         } else {
-            Config {
-                socket_path: default_socket_path(),
-                data_dir: default_data_dir(),
-                boot_workloads: Vec::new(),
-            }
+            Config::default()
         };
 
         // Overlay env vars
@@ -73,12 +92,31 @@ impl Config {
 
         // Boot workloads from env (JSON array)
         if let Ok(val) = std::env::var("EE_BOOT_WORKLOADS") {
-            match serde_json::from_str::<Vec<BootWorkload>>(&val) {
-                Ok(workloads) => config.boot_workloads = workloads,
-                Err(e) => eprintln!("easyenclave: warning: EE_BOOT_WORKLOADS parse error: {e}"),
-            }
+            config.boot_workloads = parse_boot_workloads_json(&val, "EE_BOOT_WORKLOADS")?;
         }
 
         Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_boot_workloads_json;
+
+    #[test]
+    fn parse_boot_workloads_accepts_valid_json() {
+        let workloads =
+            parse_boot_workloads_json(r#"[{"app_name":"demo","cmd":["/bin/demo"]}]"#, "test")
+                .unwrap();
+
+        assert_eq!(workloads.len(), 1);
+        assert_eq!(workloads[0].app_name, "demo");
+        assert_eq!(workloads[0].cmd.as_ref().unwrap(), &vec!["/bin/demo"]);
+    }
+
+    #[test]
+    fn parse_boot_workloads_rejects_invalid_json() {
+        let err = parse_boot_workloads_json(r#"{"app_name":"demo"}"#, "test").unwrap_err();
+        assert!(err.contains("test parse error"));
     }
 }

--- a/src/container.rs
+++ b/src/container.rs
@@ -4,11 +4,29 @@
 //! unpacks layers, and runs containers using Linux namespaces via libcontainer.
 
 use oci_distribution::client::{ClientConfig, ClientProtocol};
+use oci_distribution::manifest::{OciDescriptor, OciImageManifest};
 use oci_distribution::secrets::RegistryAuth;
 use oci_distribution::Reference;
+use std::collections::HashMap;
+use std::io::Read;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Component;
 use std::path::{Path, PathBuf};
 
-const CONTAINER_ROOT: &str = "/var/lib/easyenclave/containers";
+const DEFAULT_DATA_DIR: &str = "/var/lib/easyenclave";
+
+fn container_root() -> PathBuf {
+    let data_dir = std::env::var("EE_DATA_DIR").unwrap_or_else(|_| DEFAULT_DATA_DIR.to_string());
+    PathBuf::from(data_dir).join("containers")
+}
+
+fn container_dir(container_id: &str) -> PathBuf {
+    container_root().join(container_id)
+}
+
+fn native_dir(name: &str) -> PathBuf {
+    container_root().join("native").join(name)
+}
 
 /// Pull an OCI image, unpack it, and run it as a container. Returns a container ID.
 pub async fn pull_and_run(
@@ -19,26 +37,30 @@ pub async fn pull_and_run(
     _network_host: bool,
 ) -> Result<String, String> {
     let container_id = uuid::Uuid::new_v4().to_string();
-    let container_dir = format!("{CONTAINER_ROOT}/{name}");
-    let rootfs_dir = format!("{container_dir}/rootfs");
-    let _ = tokio::fs::create_dir_all(&rootfs_dir).await;
+    let root_path = container_root();
+    let container_dir = container_dir(&container_id);
+    let rootfs_dir = container_dir.join("rootfs");
+    tokio::fs::create_dir_all(&rootfs_dir)
+        .await
+        .map_err(|e| format!("create rootfs dir: {e}"))?;
+    let rootfs_dir_str = rootfs_dir.to_string_lossy().into_owned();
 
     // Pull and unpack image, extract entrypoint/cmd from image config
     eprintln!("easyenclave: pulling {image}");
-    let image_config = pull_image(image, &rootfs_dir).await?;
-    eprintln!("easyenclave: image unpacked to {rootfs_dir}");
+    let image_config = pull_image(image, &rootfs_dir_str).await?;
+    eprintln!("easyenclave: image unpacked to {}", rootfs_dir.display());
 
     // Ensure /etc/hosts exists in the container rootfs. Without it,
     // Go binaries (like cloudflared) resolve "localhost" via DNS
     // instead of the hosts file, failing with "no such host".
-    let etc_dir = format!("{rootfs_dir}/etc");
+    let etc_dir = rootfs_dir.join("etc");
     let _ = tokio::fs::create_dir_all(&etc_dir).await;
-    let hosts_path = format!("{etc_dir}/hosts");
+    let hosts_path = etc_dir.join("hosts");
     if !tokio::fs::try_exists(&hosts_path).await.unwrap_or(false) {
         let _ = tokio::fs::write(&hosts_path, "127.0.0.1 localhost\n::1 localhost\n").await;
     }
     // Also ensure resolv.conf so DNS works inside the container
-    let resolv_path = format!("{etc_dir}/resolv.conf");
+    let resolv_path = etc_dir.join("resolv.conf");
     if !tokio::fs::try_exists(&resolv_path).await.unwrap_or(false) {
         if let Ok(host_resolv) = tokio::fs::read_to_string("/etc/resolv.conf").await {
             let _ = tokio::fs::write(&resolv_path, host_resolv).await;
@@ -46,18 +68,18 @@ pub async fn pull_and_run(
     }
 
     // Generate OCI runtime spec using the image's entrypoint/cmd/env
-    let spec = build_spec(&rootfs_dir, env, &image_config);
-    let spec_path = format!("{container_dir}/config.json");
+    let spec = build_spec(&rootfs_dir_str, env, &image_config);
+    let spec_path = container_dir.join("config.json");
     let spec_json = serde_json::to_string_pretty(&spec).map_err(|e| format!("spec: {e}"))?;
     tokio::fs::write(&spec_path, spec_json)
         .await
         .map_err(|e| format!("write spec: {e}"))?;
 
     // Start container via libcontainer
-    let container_dir_path = PathBuf::from(&container_dir);
-    let name_clone = name.to_string();
+    let root_path_clone = root_path.clone();
+    let bundle_path = container_dir.clone();
     let cid = container_id.clone();
-    tokio::task::spawn_blocking(move || start_container(&container_dir_path, &name_clone, &cid))
+    tokio::task::spawn_blocking(move || start_container(&root_path_clone, &bundle_path, &cid))
         .await
         .map_err(|e| format!("spawn: {e}"))?
         .map_err(|e| format!("start container: {e}"))?;
@@ -66,39 +88,39 @@ pub async fn pull_and_run(
     Ok(container_id)
 }
 
-/// Pull an OCI image and extract the entrypoint + env for native execution.
-/// Returns (entrypoint_args, env_vars). The unpacked rootfs is at
-/// {CONTAINER_ROOT}/{name}/rootfs — binaries can be run directly from there.
+/// Pull an OCI image and extract a single static executable for native
+/// execution. Returns (entrypoint_args, env_vars).
 pub async fn pull_native(image: &str, name: &str) -> Result<(Vec<String>, Vec<String>), String> {
-    let container_dir = format!("{CONTAINER_ROOT}/{name}");
-    let rootfs_dir = format!("{container_dir}/rootfs");
-    let _ = tokio::fs::create_dir_all(&rootfs_dir).await;
+    eprintln!("easyenclave: pulling {image} (native static)");
+    let (reference, client, manifest, config) = fetch_manifest_and_image_config(image).await?;
+    let mut args = build_image_args(&config)?;
+    let candidate_paths = resolve_native_executable_candidates(&args[0], &config)?;
+    let extracted =
+        extract_native_binary(&client, &reference, &manifest.layers, &candidate_paths).await?;
+    validate_static_elf(&extracted.bytes)?;
 
-    eprintln!("easyenclave: pulling {image} (native)");
-    let config = pull_image(image, &rootfs_dir).await?;
-    eprintln!("easyenclave: image unpacked to {rootfs_dir}");
+    let target_dir = native_dir(name);
+    let _ = tokio::fs::remove_dir_all(&target_dir).await;
+    tokio::fs::create_dir_all(&target_dir)
+        .await
+        .map_err(|e| format!("create native dir: {e}"))?;
 
-    // Build the full command: entrypoint + cmd (per OCI spec)
-    let args = if !config.entrypoint.is_empty() {
-        let mut a = config.entrypoint;
-        a.extend(config.cmd);
-        a
-    } else if !config.cmd.is_empty() {
-        config.cmd
-    } else {
-        return Err("image has no entrypoint or cmd".into());
-    };
+    let file_name = Path::new(&extracted.source_path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("app");
+    let binary_path = target_dir.join(file_name);
+    tokio::fs::write(&binary_path, &extracted.bytes)
+        .await
+        .map_err(|e| format!("write native binary: {e}"))?;
+    std::fs::set_permissions(
+        &binary_path,
+        std::fs::Permissions::from_mode(extracted.mode),
+    )
+    .map_err(|e| format!("chmod native binary: {e}"))?;
 
-    // Rewrite paths to point into the unpacked rootfs
-    let mut resolved = args;
-    if let Some(first) = resolved.first_mut() {
-        let rootfs_path = format!("{rootfs_dir}{first}");
-        if tokio::fs::try_exists(&rootfs_path).await.unwrap_or(false) {
-            *first = rootfs_path;
-        }
-    }
-
-    Ok((resolved, config.env))
+    args[0] = binary_path.to_string_lossy().into_owned();
+    Ok((args, config.env))
 }
 
 /// OCI image config — extracted from the registry for building the runtime spec.
@@ -123,38 +145,8 @@ fn json_string_array(val: Option<&serde_json::Value>) -> Vec<String> {
 
 /// Pull an OCI image, unpack its layers, and return the image config.
 async fn pull_image(image: &str, rootfs: &str) -> Result<ImageConfig, String> {
-    let reference: Reference = image
-        .parse()
-        .map_err(|e| format!("parse ref {image}: {e}"))?;
-
-    let client_config = ClientConfig {
-        protocol: ClientProtocol::Https,
-        ..Default::default()
-    };
-    let client = oci_distribution::Client::new(client_config);
-
-    // pull_manifest_and_config resolves multi-arch indexes and returns
-    // both the manifest (for layers) and the config JSON (for
-    // entrypoint/cmd/env/workdir).
-    let (manifest, _digest, config_json) = client
-        .pull_manifest_and_config(&reference, &RegistryAuth::Anonymous)
-        .await
-        .map_err(|e| format!("pull manifest: {e}"))?;
-
-    let config_val: serde_json::Value =
-        serde_json::from_str(&config_json).map_err(|e| format!("parse image config: {e}"))?;
-    let c = &config_val["config"];
-    let image_config = ImageConfig {
-        entrypoint: json_string_array(c.get("Entrypoint")),
-        cmd: json_string_array(c.get("Cmd")),
-        env: json_string_array(c.get("Env")),
-        working_dir: c
-            .get("WorkingDir")
-            .and_then(|v| v.as_str())
-            .unwrap_or("/")
-            .to_string(),
-    };
-
+    let (reference, client, manifest, image_config) =
+        fetch_manifest_and_image_config(image).await?;
     let layers = manifest.layers.clone();
 
     for layer in &layers {
@@ -174,6 +166,409 @@ async fn pull_image(image: &str, rootfs: &str) -> Result<ImageConfig, String> {
     }
 
     Ok(image_config)
+}
+
+async fn fetch_manifest_and_image_config(
+    image: &str,
+) -> Result<
+    (
+        Reference,
+        oci_distribution::Client,
+        OciImageManifest,
+        ImageConfig,
+    ),
+    String,
+> {
+    let reference: Reference = image
+        .parse()
+        .map_err(|e| format!("parse ref {image}: {e}"))?;
+
+    let client_config = ClientConfig {
+        protocol: ClientProtocol::Https,
+        ..Default::default()
+    };
+    let client = oci_distribution::Client::new(client_config);
+    let (manifest, _digest, config_json) = client
+        .pull_manifest_and_config(&reference, &RegistryAuth::Anonymous)
+        .await
+        .map_err(|e| format!("pull manifest: {e}"))?;
+
+    let config_val: serde_json::Value =
+        serde_json::from_str(&config_json).map_err(|e| format!("parse image config: {e}"))?;
+    let c = &config_val["config"];
+    let image_config = ImageConfig {
+        entrypoint: json_string_array(c.get("Entrypoint")),
+        cmd: json_string_array(c.get("Cmd")),
+        env: json_string_array(c.get("Env")),
+        working_dir: c
+            .get("WorkingDir")
+            .and_then(|v| v.as_str())
+            .unwrap_or("/")
+            .to_string(),
+    };
+
+    Ok((reference, client, manifest, image_config))
+}
+
+fn build_image_args(image_config: &ImageConfig) -> Result<Vec<String>, String> {
+    if !image_config.entrypoint.is_empty() {
+        let mut args = image_config.entrypoint.clone();
+        args.extend(image_config.cmd.clone());
+        Ok(args)
+    } else if !image_config.cmd.is_empty() {
+        Ok(image_config.cmd.clone())
+    } else {
+        Err("image has no entrypoint or cmd".into())
+    }
+}
+
+fn resolve_native_executable_candidates(
+    program: &str,
+    image_config: &ImageConfig,
+) -> Result<Vec<String>, String> {
+    if program.contains('/') {
+        return Ok(vec![resolve_image_program_path(
+            program,
+            &image_config.working_dir,
+        )?]);
+    }
+
+    let path_env = image_config
+        .env
+        .iter()
+        .find_map(|entry| entry.strip_prefix("PATH=").map(str::to_string))
+        .unwrap_or_else(|| "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".into());
+
+    let mut candidates = Vec::new();
+    for dir in path_env.split(':').filter(|dir| !dir.is_empty()) {
+        candidates.push(resolve_image_program_path(
+            &format!("{dir}/{program}"),
+            &image_config.working_dir,
+        )?);
+    }
+
+    if candidates.is_empty() {
+        Err(format!("could not resolve executable path for {program}"))
+    } else {
+        Ok(candidates)
+    }
+}
+
+fn resolve_image_program_path(program: &str, working_dir: &str) -> Result<String, String> {
+    let base = if program.starts_with('/') {
+        PathBuf::from(program)
+    } else {
+        PathBuf::from(if working_dir.is_empty() {
+            "/"
+        } else {
+            working_dir
+        })
+        .join(program)
+    };
+    normalize_image_path(&base)
+}
+
+fn normalize_image_path(path: &Path) -> Result<String, String> {
+    let mut parts = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::RootDir | Component::CurDir => {}
+            Component::Normal(part) => parts.push(part.to_string_lossy().into_owned()),
+            Component::ParentDir => {
+                if parts.pop().is_none() {
+                    return Err(format!("path escapes image root: {}", path.display()));
+                }
+            }
+            Component::Prefix(_) => {
+                return Err(format!("unsupported image path: {}", path.display()));
+            }
+        }
+    }
+
+    Ok(format!("/{}", parts.join("/")))
+}
+
+#[derive(Clone, Debug)]
+struct NativeBinary {
+    source_path: String,
+    bytes: Vec<u8>,
+    mode: u32,
+}
+
+async fn extract_native_binary(
+    client: &oci_distribution::Client,
+    reference: &Reference,
+    layers: &[OciDescriptor],
+    candidate_paths: &[String],
+) -> Result<NativeBinary, String> {
+    let mut states: HashMap<String, Option<NativeBinary>> = candidate_paths
+        .iter()
+        .cloned()
+        .map(|path| (path, None))
+        .collect();
+
+    for layer in layers {
+        let mut layer_data = Vec::new();
+        client
+            .pull_blob(reference, layer, &mut layer_data)
+            .await
+            .map_err(|e| format!("pull layer {}: {e}", layer.digest))?;
+        scan_native_layer(&layer_data, &mut states)?;
+    }
+
+    candidate_paths
+        .iter()
+        .find_map(|path| states.get(path).and_then(|state| state.clone()))
+        .ok_or_else(|| {
+            format!(
+                "native mode could not find executable in image: {}",
+                candidate_paths.join(", ")
+            )
+        })
+}
+
+fn scan_native_layer(
+    data: &[u8],
+    states: &mut HashMap<String, Option<NativeBinary>>,
+) -> Result<(), String> {
+    use flate2::read::GzDecoder;
+    use tar::Archive;
+
+    let decoder = GzDecoder::new(data);
+    let mut archive = Archive::new(decoder);
+    let candidate_paths: Vec<String> = states.keys().cloned().collect();
+
+    for entry_result in archive
+        .entries()
+        .map_err(|e| format!("read tar entries: {e}"))?
+    {
+        let mut entry = entry_result.map_err(|e| format!("read tar entry: {e}"))?;
+        let path = normalize_image_path(
+            &entry
+                .path()
+                .map_err(|e| format!("read tar path: {e}"))?
+                .into_owned(),
+        )?;
+
+        if let Some(opaque_dir) = opaque_whiteout_dir(&path) {
+            for candidate in &candidate_paths {
+                if candidate.starts_with(&(opaque_dir.clone() + "/")) {
+                    states.insert(candidate.clone(), None);
+                }
+            }
+            continue;
+        }
+
+        if let Some(whiteout_target) = whiteout_target_path(&path) {
+            for candidate in &candidate_paths {
+                if candidate == &whiteout_target
+                    || candidate.starts_with(&(whiteout_target.clone() + "/"))
+                {
+                    states.insert(candidate.clone(), None);
+                }
+            }
+            continue;
+        }
+
+        if !states.contains_key(&path) {
+            continue;
+        }
+
+        let entry_type = entry.header().entry_type();
+        if entry_type.is_symlink() || entry_type.is_hard_link() {
+            return Err(format!(
+                "native mode does not support symlinked executables: {path}"
+            ));
+        }
+        if !entry_type.is_file() {
+            continue;
+        }
+
+        let mode = entry.header().mode().unwrap_or(0o755);
+        let mut bytes = Vec::new();
+        entry
+            .read_to_end(&mut bytes)
+            .map_err(|e| format!("read executable bytes: {e}"))?;
+        states.insert(
+            path.clone(),
+            Some(NativeBinary {
+                source_path: path,
+                bytes,
+                mode,
+            }),
+        );
+    }
+
+    Ok(())
+}
+
+fn opaque_whiteout_dir(path: &str) -> Option<String> {
+    if !path.ends_with("/.wh..wh..opq") && path != "/.wh..wh..opq" {
+        return None;
+    }
+
+    let parent = Path::new(path).parent()?;
+    normalize_image_path(parent).ok()
+}
+
+fn whiteout_target_path(path: &str) -> Option<String> {
+    let file_name = Path::new(path).file_name()?.to_str()?;
+    let target_name = file_name.strip_prefix(".wh.")?;
+    if target_name == ".wh..opq" {
+        return None;
+    }
+
+    let parent = Path::new(path).parent()?;
+    normalize_image_path(&parent.join(target_name)).ok()
+}
+
+#[derive(Clone, Copy)]
+enum ElfClass {
+    Elf32,
+    Elf64,
+}
+
+#[derive(Clone, Copy)]
+enum ElfEndian {
+    Little,
+    Big,
+}
+
+fn validate_static_elf(bytes: &[u8]) -> Result<(), String> {
+    if bytes.len() < 0x34 || &bytes[..4] != b"\x7FELF" {
+        return Err("native mode requires a static ELF executable".into());
+    }
+
+    let class = match bytes[4] {
+        1 => ElfClass::Elf32,
+        2 => ElfClass::Elf64,
+        _ => return Err("native mode requires a supported ELF executable".into()),
+    };
+    let endian = match bytes[5] {
+        1 => ElfEndian::Little,
+        2 => ElfEndian::Big,
+        _ => return Err("native mode requires a supported ELF executable".into()),
+    };
+
+    let (phoff, phentsize, phnum) = match class {
+        ElfClass::Elf32 => (
+            read_u32(bytes, 28, endian)? as u64,
+            read_u16(bytes, 42, endian)? as u64,
+            read_u16(bytes, 44, endian)? as u64,
+        ),
+        ElfClass::Elf64 => (
+            read_u64(bytes, 32, endian)?,
+            read_u16(bytes, 54, endian)? as u64,
+            read_u16(bytes, 56, endian)? as u64,
+        ),
+    };
+
+    if phoff == 0 || phentsize == 0 || phnum == 0 {
+        return Err("native mode requires an executable ELF with program headers".into());
+    }
+
+    let ph_table_len = phentsize
+        .checked_mul(phnum)
+        .ok_or_else(|| "invalid ELF program header table".to_string())?;
+    let ph_table_end = phoff
+        .checked_add(ph_table_len)
+        .ok_or_else(|| "invalid ELF program header table".to_string())?;
+    if ph_table_end as usize > bytes.len() {
+        return Err("invalid ELF program header table".into());
+    }
+
+    let mut dynamic_segment = None;
+    for index in 0..phnum {
+        let entry_offset = (phoff + index * phentsize) as usize;
+        let p_type = read_u32(bytes, entry_offset, endian)?;
+        if p_type == 3 {
+            return Err("native mode requires a static ELF executable".into());
+        }
+        if p_type == 2 {
+            dynamic_segment = Some(match class {
+                ElfClass::Elf32 => (
+                    read_u32(bytes, entry_offset + 4, endian)? as u64,
+                    read_u32(bytes, entry_offset + 16, endian)? as u64,
+                ),
+                ElfClass::Elf64 => (
+                    read_u64(bytes, entry_offset + 8, endian)?,
+                    read_u64(bytes, entry_offset + 32, endian)?,
+                ),
+            });
+        }
+    }
+
+    if let Some((offset, size)) = dynamic_segment {
+        let entry_size = match class {
+            ElfClass::Elf32 => 8usize,
+            ElfClass::Elf64 => 16usize,
+        };
+        let end = offset
+            .checked_add(size)
+            .ok_or_else(|| "invalid ELF dynamic section".to_string())?;
+        if end as usize > bytes.len() {
+            return Err("invalid ELF dynamic section".into());
+        }
+
+        let mut cursor = offset as usize;
+        while cursor + entry_size <= end as usize {
+            let tag = match class {
+                ElfClass::Elf32 => read_i32(bytes, cursor, endian)? as i64,
+                ElfClass::Elf64 => read_i64(bytes, cursor, endian)?,
+            };
+            if tag == 0 {
+                break;
+            }
+            if tag == 1 {
+                return Err("native mode requires a static ELF executable".into());
+            }
+            cursor += entry_size;
+        }
+    }
+
+    Ok(())
+}
+
+fn read_u16(bytes: &[u8], offset: usize, endian: ElfEndian) -> Result<u16, String> {
+    let slice = bytes
+        .get(offset..offset + 2)
+        .ok_or_else(|| "truncated ELF".to_string())?;
+    Ok(match endian {
+        ElfEndian::Little => u16::from_le_bytes([slice[0], slice[1]]),
+        ElfEndian::Big => u16::from_be_bytes([slice[0], slice[1]]),
+    })
+}
+
+fn read_u32(bytes: &[u8], offset: usize, endian: ElfEndian) -> Result<u32, String> {
+    let slice = bytes
+        .get(offset..offset + 4)
+        .ok_or_else(|| "truncated ELF".to_string())?;
+    Ok(match endian {
+        ElfEndian::Little => u32::from_le_bytes([slice[0], slice[1], slice[2], slice[3]]),
+        ElfEndian::Big => u32::from_be_bytes([slice[0], slice[1], slice[2], slice[3]]),
+    })
+}
+
+fn read_u64(bytes: &[u8], offset: usize, endian: ElfEndian) -> Result<u64, String> {
+    let slice = bytes
+        .get(offset..offset + 8)
+        .ok_or_else(|| "truncated ELF".to_string())?;
+    Ok(match endian {
+        ElfEndian::Little => u64::from_le_bytes([
+            slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7],
+        ]),
+        ElfEndian::Big => u64::from_be_bytes([
+            slice[0], slice[1], slice[2], slice[3], slice[4], slice[5], slice[6], slice[7],
+        ]),
+    })
+}
+
+fn read_i32(bytes: &[u8], offset: usize, endian: ElfEndian) -> Result<i32, String> {
+    Ok(read_u32(bytes, offset, endian)? as i32)
+}
+
+fn read_i64(bytes: &[u8], offset: usize, endian: ElfEndian) -> Result<i64, String> {
+    Ok(read_u64(bytes, offset, endian)? as i64)
 }
 
 /// Unpack a gzipped tar layer into the rootfs.
@@ -276,14 +671,25 @@ fn build_spec(
 }
 
 /// Start a container using libcontainer.
-fn start_container(container_dir: &Path, name: &str, _container_id: &str) -> Result<(), String> {
+fn start_container(root_path: &Path, bundle: &Path, container_id: &str) -> Result<(), String> {
     use libcontainer::container::builder::ContainerBuilder;
     use libcontainer::syscall::syscall::SyscallType;
 
-    let mut container = ContainerBuilder::new(name.to_string(), SyscallType::default())
-        .with_root_path(container_dir.to_path_buf())
+    let stdout_log = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(bundle.join("output.log"))
+        .map_err(|e| format!("open output.log: {e}"))?;
+    let stderr_log = stdout_log
+        .try_clone()
+        .map_err(|e| format!("clone output.log: {e}"))?;
+
+    let mut container = ContainerBuilder::new(container_id.to_string(), SyscallType::default())
+        .with_root_path(root_path.to_path_buf())
         .map_err(|e| format!("root path: {e}"))?
-        .as_init(container_dir)
+        .with_stdout(stdout_log)
+        .with_stderr(stderr_log)
+        .as_init(bundle)
         .with_systemd(false)
         .build()
         .map_err(|e| format!("build container: {e}"))?;
@@ -294,12 +700,9 @@ fn start_container(container_dir: &Path, name: &str, _container_id: &str) -> Res
 }
 
 /// Execute a command inside a running container. Returns (exit_code, stdout, stderr).
-pub async fn exec(container_name: &str, cmd: &[String]) -> Result<(i64, String, String), String> {
+pub async fn exec(container_id: &str, cmd: &[String]) -> Result<(i64, String, String), String> {
     // For now, use nsenter via the container's PID namespace
-    let container_dir = format!("{CONTAINER_ROOT}/{container_name}");
-    let pid_file = format!("{container_dir}/state.json");
-
-    let pid = read_container_pid(&pid_file).await?;
+    let pid = read_container_pid(&container_dir(container_id).join("state.json")).await?;
 
     let mut args = vec![
         "-t".to_string(),
@@ -329,24 +732,23 @@ pub async fn exec(container_name: &str, cmd: &[String]) -> Result<(i64, String, 
 }
 
 /// Read the init PID from the container state.
-async fn read_container_pid(state_path: &str) -> Result<u32, String> {
+async fn read_container_pid(state_path: &Path) -> Result<u32, String> {
     let data = tokio::fs::read_to_string(state_path)
         .await
         .map_err(|e| format!("read state: {e}"))?;
     let state: serde_json::Value =
         serde_json::from_str(&data).map_err(|e| format!("parse state: {e}"))?;
-    state["init_process_start"]
-        .as_u64()
-        .or_else(|| state["pid"].as_u64())
+    state["pid"]
+        .as_i64()
+        .filter(|pid| *pid > 0)
         .map(|p| p as u32)
         .ok_or_else(|| "no pid in container state".into())
 }
 
 /// Stop a container by killing its init process.
 pub async fn stop(container_id: &str) -> Result<(), String> {
-    // Find by ID or name in CONTAINER_ROOT
-    let container_dir = format!("{CONTAINER_ROOT}/{container_id}");
-    if let Ok(pid) = read_container_pid(&format!("{container_dir}/state.json")).await {
+    let container_dir = container_dir(container_id);
+    if let Ok(pid) = read_container_pid(&container_dir.join("state.json")).await {
         crate::process::kill_process(pid).await?;
     }
     let _ = tokio::fs::remove_dir_all(&container_dir).await;
@@ -355,8 +757,7 @@ pub async fn stop(container_id: &str) -> Result<(), String> {
 
 /// Check if a container is running.
 pub async fn is_running(container_id: &str) -> bool {
-    let state_path = format!("{CONTAINER_ROOT}/{container_id}/state.json");
-    if let Ok(pid) = read_container_pid(&state_path).await {
+    if let Ok(pid) = read_container_pid(&container_dir(container_id).join("state.json")).await {
         Path::new(&format!("/proc/{pid}")).exists()
     } else {
         false
@@ -364,10 +765,123 @@ pub async fn is_running(container_id: &str) -> bool {
 }
 
 /// Get the last N lines of container logs (from stdout capture file).
-pub async fn logs(container_id: &str, _tail: usize) -> Result<Vec<String>, String> {
-    let log_path = format!("{CONTAINER_ROOT}/{container_id}/output.log");
+pub async fn logs(container_id: &str, tail: usize) -> Result<Vec<String>, String> {
+    let log_path = container_dir(container_id).join("output.log");
     match tokio::fs::read_to_string(&log_path).await {
-        Ok(content) => Ok(content.lines().map(String::from).collect()),
+        Ok(content) => {
+            if tail == 0 {
+                return Ok(Vec::new());
+            }
+            let mut lines: Vec<String> = content.lines().map(String::from).collect();
+            if lines.len() > tail {
+                lines = lines.split_off(lines.len() - tail);
+            }
+            Ok(lines)
+        }
         Err(_) => Ok(Vec::new()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        normalize_image_path, opaque_whiteout_dir, resolve_native_executable_candidates,
+        validate_static_elf, whiteout_target_path, ImageConfig,
+    };
+    use std::path::Path;
+
+    fn image_config(
+        entrypoint: &[&str],
+        cmd: &[&str],
+        env: &[&str],
+        working_dir: &str,
+    ) -> ImageConfig {
+        ImageConfig {
+            entrypoint: entrypoint.iter().map(|s| s.to_string()).collect(),
+            cmd: cmd.iter().map(|s| s.to_string()).collect(),
+            env: env.iter().map(|s| s.to_string()).collect(),
+            working_dir: working_dir.to_string(),
+        }
+    }
+
+    fn minimal_elf64(ph_type: u32, dynamic_tag: Option<i64>) -> Vec<u8> {
+        let phoff = 64u64;
+        let phentsize = 56u16;
+        let phnum = 1u16;
+        let mut bytes = vec![0u8; 64 + 56 + 16];
+        bytes[..4].copy_from_slice(b"\x7FELF");
+        bytes[4] = 2;
+        bytes[5] = 1;
+        bytes[6] = 1;
+        bytes[16..18].copy_from_slice(&2u16.to_le_bytes());
+        bytes[18..20].copy_from_slice(&62u16.to_le_bytes());
+        bytes[20..24].copy_from_slice(&1u32.to_le_bytes());
+        bytes[32..40].copy_from_slice(&phoff.to_le_bytes());
+        bytes[52..54].copy_from_slice(&64u16.to_le_bytes());
+        bytes[54..56].copy_from_slice(&phentsize.to_le_bytes());
+        bytes[56..58].copy_from_slice(&phnum.to_le_bytes());
+
+        let ph = &mut bytes[64..120];
+        ph[..4].copy_from_slice(&ph_type.to_le_bytes());
+        ph[8..16].copy_from_slice(&120u64.to_le_bytes());
+        ph[32..40].copy_from_slice(&16u64.to_le_bytes());
+
+        if let Some(tag) = dynamic_tag {
+            bytes[120..128].copy_from_slice(&tag.to_le_bytes());
+        }
+
+        bytes
+    }
+
+    #[test]
+    fn resolve_native_candidates_uses_image_path() {
+        let config = image_config(&["demo"], &[], &["PATH=/usr/local/bin:/usr/bin"], "/");
+        let candidates = resolve_native_executable_candidates("demo", &config).unwrap();
+        assert_eq!(candidates, vec!["/usr/local/bin/demo", "/usr/bin/demo"]);
+    }
+
+    #[test]
+    fn resolve_native_candidates_resolves_relative_workdir() {
+        let config = image_config(&["./demo"], &[], &[], "/work");
+        let candidates = resolve_native_executable_candidates("./demo", &config).unwrap();
+        assert_eq!(candidates, vec!["/work/demo"]);
+    }
+
+    #[test]
+    fn normalize_image_path_collapses_dot_segments() {
+        assert_eq!(
+            normalize_image_path(Path::new("/opt/./app/../demo")).unwrap(),
+            "/opt/demo"
+        );
+    }
+
+    #[test]
+    fn whiteout_helpers_map_targets() {
+        assert_eq!(
+            whiteout_target_path("/usr/bin/.wh.demo").unwrap(),
+            "/usr/bin/demo"
+        );
+        assert_eq!(
+            opaque_whiteout_dir("/usr/bin/.wh..wh..opq").unwrap(),
+            "/usr/bin"
+        );
+    }
+
+    #[test]
+    fn validate_static_elf_accepts_plain_executable() {
+        let elf = minimal_elf64(1, None);
+        validate_static_elf(&elf).unwrap();
+    }
+
+    #[test]
+    fn validate_static_elf_rejects_interp() {
+        let elf = minimal_elf64(3, None);
+        assert!(validate_static_elf(&elf).is_err());
+    }
+
+    #[test]
+    fn validate_static_elf_rejects_needed_dynamic_entry() {
+        let elf = minimal_elf64(2, Some(1));
+        assert!(validate_static_elf(&elf).is_err());
     }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -58,7 +58,7 @@ pub fn maybe_init() {
             if let Some(kv) = param.strip_prefix("ee.") {
                 if let Some((key, val)) = kv.split_once('=') {
                     std::env::set_var(key, val);
-                    eprintln!("easyenclave: init: cmdline env {key}={val}");
+                    eprintln!("easyenclave: init: cmdline env {key}=<redacted>");
                 }
             }
             if let Some(hostname) = param.strip_prefix("hostname=") {
@@ -101,7 +101,7 @@ pub fn maybe_init() {
                 }
                 if let Some((key, val)) = line.split_once('=') {
                     std::env::set_var(key.trim(), val.trim());
-                    eprintln!("easyenclave: init: config env {key}={val}");
+                    eprintln!("easyenclave: init: config env {key}=<redacted>");
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,9 @@
+//! EasyEnclave runtime library.
+
+pub mod attestation;
+pub mod config;
+pub mod container;
+pub mod init;
+pub mod process;
+pub mod socket;
+pub mod workload;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,4 @@
-mod attestation;
-mod config;
-mod container;
-mod init;
-mod process;
-mod socket;
-mod workload;
-
+use easyenclave::{attestation, config, init, socket, workload};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -24,18 +17,33 @@ async fn main() {
         }
     };
 
+    std::env::set_var("EE_DATA_DIR", &cfg.data_dir);
+    std::env::set_var("EE_SOCKET_PATH", &cfg.socket_path);
+
     // Ensure data directory exists
-    let _ = std::fs::create_dir_all(&cfg.data_dir);
-    let _ = std::fs::create_dir_all(format!("{}/workloads/logs", cfg.data_dir));
+    if let Err(e) = std::fs::create_dir_all(&cfg.data_dir) {
+        eprintln!(
+            "easyenclave: failed to create data dir {}: {e}",
+            cfg.data_dir
+        );
+        std::process::exit(1);
+    }
+    if let Err(e) = std::fs::create_dir_all(format!("{}/workloads/logs", cfg.data_dir)) {
+        eprintln!(
+            "easyenclave: failed to create workload log dir under {}: {e}",
+            cfg.data_dir
+        );
+        std::process::exit(1);
+    }
 
     // 3. Detect attestation backend
-    let attestation = attestation::detect().unwrap_or_else(|e| {
+    let attestation_backend = attestation::detect().unwrap_or_else(|e| {
         eprintln!("easyenclave: FATAL: {e}");
         std::process::exit(1);
     });
     eprintln!(
         "easyenclave: attestation backend: {}",
-        attestation.attestation_type()
+        attestation_backend.attestation_type()
     );
 
     // 4. Create empty deployments
@@ -54,8 +62,10 @@ async fn main() {
             post_deploy: None,
             native: bw.native,
         };
-        let (id, _status) = workload::execute_deploy(&deployments, req).await;
-        eprintln!("easyenclave: boot workload {} -> {id}", bw.app_name);
+        match workload::execute_deploy(&deployments, req).await {
+            Ok((id, _status)) => eprintln!("easyenclave: boot workload {} -> {id}", bw.app_name),
+            Err(e) => eprintln!("easyenclave: boot workload {} rejected: {e}", bw.app_name),
+        }
     }
 
     let start_time = std::time::Instant::now();
@@ -82,7 +92,7 @@ async fn main() {
     let server = socket::SocketServer {
         socket_path: cfg.socket_path.clone(),
         deployments,
-        attestation: Arc::new(attestation),
+        attestation: Arc::from(attestation_backend),
         start_time,
     };
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,19 +1,35 @@
 //! Process manager -- run workloads as plain processes on the VM.
 
+use std::path::PathBuf;
 use tokio::process::{Child, Command};
+
+const DEFAULT_DATA_DIR: &str = "/var/lib/easyenclave";
+
+fn workload_logs_dir() -> PathBuf {
+    let data_dir = std::env::var("EE_DATA_DIR").unwrap_or_else(|_| DEFAULT_DATA_DIR.to_string());
+    PathBuf::from(data_dir).join("workloads/logs")
+}
+
+fn shell_escape(arg: &str) -> String {
+    format!("'{}'", arg.replace('\'', "'\"'\"'"))
+}
+
+fn build_tty_command(program: &str, args: &[&str]) -> String {
+    std::iter::once(program)
+        .chain(args.iter().copied())
+        .map(shell_escape)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
 
 /// Spawn a command directly on the VM.
 pub async fn spawn_command(program: &str, args: &[&str], tty: bool) -> Result<Child, String> {
-    let _ = tokio::fs::create_dir_all("/var/lib/easyenclave/workloads/logs").await;
+    let _ = tokio::fs::create_dir_all(workload_logs_dir()).await;
 
     let mut cmd = if tty {
         let mut c = Command::new("script");
         c.arg("-qfc");
-        let full_cmd = std::iter::once(program)
-            .chain(args.iter().copied())
-            .collect::<Vec<_>>()
-            .join(" ");
-        c.arg(full_cmd);
+        c.arg(build_tty_command(program, args));
         c.arg("/dev/null");
         c.env("TERM", "xterm-256color");
         c
@@ -46,7 +62,7 @@ pub async fn spawn_command_with_env(
     tty: bool,
     env: &std::collections::HashMap<String, String>,
 ) -> Result<Child, String> {
-    let _ = tokio::fs::create_dir_all("/var/lib/easyenclave/workloads/logs").await;
+    let _ = tokio::fs::create_dir_all(workload_logs_dir()).await;
 
     let mut cmd = Command::new(program);
     cmd.args(args);
@@ -82,4 +98,15 @@ pub async fn kill_process(pid: u32) -> Result<(), String> {
         .output()
         .await;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_tty_command;
+
+    #[test]
+    fn build_tty_command_shell_escapes_arguments() {
+        let cmd = build_tty_command("echo", &["hello world", "quote's"]);
+        assert_eq!(cmd, "'echo' 'hello world' 'quote'\"'\"'s'");
+    }
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -2,7 +2,7 @@
 
 use serde_json::{json, Value};
 use std::sync::Arc;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::net::UnixListener;
 
 use crate::attestation::AttestationBackend;
@@ -11,7 +11,7 @@ use crate::workload::{DeployRequest, Deployments};
 pub struct SocketServer {
     pub socket_path: String,
     pub deployments: Deployments,
-    pub attestation: Arc<Box<dyn AttestationBackend>>,
+    pub attestation: Arc<dyn AttestationBackend>,
     pub start_time: std::time::Instant,
 }
 
@@ -41,22 +41,38 @@ impl SocketServer {
             let attestation = self.attestation.clone();
             let start_time = self.start_time;
 
-            tokio::spawn(async move {
-                let (reader, mut writer) = stream.into_split();
-                let mut lines = BufReader::new(reader).lines();
+            tokio::spawn(serve_stream(stream, deployments, attestation, start_time));
+        }
+    }
+}
 
-                while let Ok(Some(line)) = lines.next_line().await {
-                    let response =
-                        handle_request(&line, &deployments, &attestation, start_time).await;
-                    let mut out = serde_json::to_string(&response).unwrap_or_else(|_| {
-                        r#"{"ok":false,"error":"serialize error"}"#.to_string()
-                    });
-                    out.push('\n');
-                    if writer.write_all(out.as_bytes()).await.is_err() {
-                        break;
-                    }
-                }
-            });
+async fn serve_stream(
+    stream: tokio::net::UnixStream,
+    deployments: Deployments,
+    attestation: Arc<dyn AttestationBackend>,
+    start_time: std::time::Instant,
+) {
+    serve_io(stream, deployments, attestation, start_time).await;
+}
+
+async fn serve_io<S>(
+    stream: S,
+    deployments: Deployments,
+    attestation: Arc<dyn AttestationBackend>,
+    start_time: std::time::Instant,
+) where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let (reader, mut writer) = tokio::io::split(stream);
+    let mut lines = BufReader::new(reader).lines();
+
+    while let Ok(Some(line)) = lines.next_line().await {
+        let response = handle_request(&line, &deployments, &attestation, start_time).await;
+        let mut out = serde_json::to_string(&response)
+            .unwrap_or_else(|_| r#"{"ok":false,"error":"serialize error"}"#.to_string());
+        out.push('\n');
+        if writer.write_all(out.as_bytes()).await.is_err() {
+            break;
         }
     }
 }
@@ -64,7 +80,7 @@ impl SocketServer {
 async fn handle_request(
     line: &str,
     deployments: &Deployments,
-    attestation: &Arc<Box<dyn AttestationBackend>>,
+    attestation: &Arc<dyn AttestationBackend>,
     start_time: std::time::Instant,
 ) -> Value {
     let req: Value = match serde_json::from_str(line) {
@@ -91,7 +107,7 @@ async fn handle_request(
 
 async fn handle_health(
     deployments: &Deployments,
-    attestation: &Arc<Box<dyn AttestationBackend>>,
+    attestation: &Arc<dyn AttestationBackend>,
     start_time: std::time::Instant,
 ) -> Value {
     let count = deployments.lock().await.len();
@@ -103,7 +119,7 @@ async fn handle_health(
     })
 }
 
-fn handle_attest(req: &Value, attestation: &Arc<Box<dyn AttestationBackend>>) -> Value {
+fn handle_attest(req: &Value, attestation: &Arc<dyn AttestationBackend>) -> Value {
     let nonce_b64 = req.get("nonce").and_then(|n| n.as_str()).unwrap_or("");
     let nonce_bytes = if nonce_b64.is_empty() {
         Vec::new()
@@ -135,8 +151,10 @@ async fn handle_deploy(req: &Value, deployments: &Deployments) -> Value {
         Err(e) => return json!({"ok": false, "error": format!("invalid deploy request: {e}")}),
     };
 
-    let (id, status) = crate::workload::execute_deploy(deployments, deploy_req).await;
-    json!({"ok": true, "id": id, "status": status})
+    match crate::workload::execute_deploy(deployments, deploy_req).await {
+        Ok((id, status)) => json!({"ok": true, "id": id, "status": status}),
+        Err(e) => json!({"ok": false, "error": e}),
+    }
 }
 
 async fn handle_list(deployments: &Deployments) -> Value {
@@ -233,5 +251,86 @@ async fn handle_logs(req: &Value, deployments: &Deployments) -> Value {
             Err(e) => json!({"ok": false, "error": e}),
         },
         None => json!({"ok": true, "lines": [], "note": "process workload (no container logs)"}),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{serve_io, SocketServer};
+    use crate::attestation::AttestationBackend;
+    use crate::workload::Deployments;
+    use serde_json::Value;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::sync::Mutex;
+
+    struct FakeAttestation;
+
+    impl AttestationBackend for FakeAttestation {
+        fn attestation_type(&self) -> &str {
+            "tdx"
+        }
+
+        fn generate_quote_b64(&self) -> Option<String> {
+            Some("quote".into())
+        }
+
+        fn generate_quote_with_nonce(&self, _nonce: &[u8]) -> Option<String> {
+            Some("quote-with-nonce".into())
+        }
+    }
+
+    async fn send_request(request: &str) -> Value {
+        let deployments: Deployments = Arc::new(Mutex::new(HashMap::new()));
+        let attestation: Arc<dyn AttestationBackend> = Arc::new(FakeAttestation);
+        let (client, server) = tokio::io::duplex(4096);
+
+        tokio::spawn(serve_io(
+            server,
+            deployments,
+            attestation,
+            std::time::Instant::now(),
+        ));
+
+        let (reader, mut writer) = tokio::io::split(client);
+        writer
+            .write_all(format!("{request}\n").as_bytes())
+            .await
+            .unwrap();
+        let mut lines = BufReader::new(reader).lines();
+        let response = lines.next_line().await.unwrap().unwrap();
+        serde_json::from_str(&response).unwrap()
+    }
+
+    #[tokio::test]
+    async fn health_request_works_over_real_stream_protocol() {
+        let response = send_request(r#"{"method":"health"}"#).await;
+
+        assert_eq!(response["ok"], true);
+        assert_eq!(response["attestation_type"], "tdx");
+        assert_eq!(response["workloads"], 0);
+    }
+
+    #[tokio::test]
+    async fn deploy_rejects_empty_request_immediately() {
+        let response = send_request(r#"{"method":"deploy"}"#).await;
+
+        assert_eq!(response["ok"], false);
+        assert_eq!(response["error"], "either image or cmd must be specified");
+    }
+
+    #[test]
+    fn socket_server_holds_trait_object_without_boxing() {
+        let deployments: Deployments = Arc::new(Mutex::new(HashMap::new()));
+        let attestation: Arc<dyn AttestationBackend> = Arc::new(FakeAttestation);
+        let server = SocketServer {
+            socket_path: "/tmp/ignored.sock".into(),
+            deployments,
+            attestation,
+            start_time: std::time::Instant::now(),
+        };
+
+        assert_eq!(server.attestation.attestation_type(), "tdx");
     }
 }

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -41,18 +41,36 @@ pub struct DeployRequest {
     /// Commands to exec inside the container after it starts.
     #[serde(default)]
     pub post_deploy: Option<Vec<Vec<String>>>,
-    /// Run the OCI image natively (extract binary, exec on host).
+    /// Run the OCI image natively by extracting a single static ELF
+    /// executable and exec'ing it on the host.
     #[serde(default)]
     pub native: bool,
 }
 
 pub type Deployments = Arc<Mutex<HashMap<String, DeploymentInfo>>>;
 
+impl DeployRequest {
+    fn validate(&self) -> Result<(), String> {
+        if self.image.is_none() && self.cmd.is_empty() {
+            return Err("either image or cmd must be specified".into());
+        }
+        if self.native && self.image.is_none() {
+            return Err("native deployments require an image".into());
+        }
+        Ok(())
+    }
+}
+
 // ── Deploy ───────────────────────────────────────────────────────────────────
 
 /// Start a deployment. Spawns run_deploy on tokio and returns immediately
 /// with (deployment_id, "deploying").
-pub async fn execute_deploy(deployments: &Deployments, req: DeployRequest) -> (String, String) {
+pub async fn execute_deploy(
+    deployments: &Deployments,
+    req: DeployRequest,
+) -> Result<(String, String), String> {
+    req.validate()?;
+
     let dep_id = uuid::Uuid::new_v4().to_string();
     let app_name = req.app_name.clone().unwrap_or_else(|| "unnamed".into());
 
@@ -80,7 +98,7 @@ pub async fn execute_deploy(deployments: &Deployments, req: DeployRequest) -> (S
         run_deploy(deployments_clone, dep_id, app_name, req).await;
     });
 
-    (return_id, "deploying".into())
+    Ok((return_id, "deploying".into()))
 }
 
 async fn run_deploy(
@@ -109,7 +127,7 @@ async fn run_deploy(
     }
 
     if req.native && req.image.is_some() {
-        // Native path: pull OCI image, unpack layers, run entrypoint
+        // Native path: extract a single static ELF from the image and run it
         // directly on the host. Full access to host filesystem + sockets.
         let image = req.image.as_ref().unwrap();
         match container::pull_native(image, &app_name).await {
@@ -141,8 +159,12 @@ async fn run_deploy(
                             info.status = "running".into();
                         }
                         drop(deps);
+                        let deployments_for_wait = deployments.clone();
+                        let dep_id_for_wait = dep_id.clone();
                         tokio::spawn(async move {
-                            let _ = child.wait().await;
+                            let outcome = child.wait().await;
+                            record_process_exit(&deployments_for_wait, &dep_id_for_wait, outcome)
+                                .await;
                         });
                     }
                     Err(e) => {
@@ -165,6 +187,7 @@ async fn run_deploy(
                     info.status = "running".into();
                 }
                 drop(deps);
+                spawn_container_monitor(deployments.clone(), dep_id.clone(), container_id.clone());
 
                 // Run post-deploy commands inside the container
                 if let Some(ref commands) = req.post_deploy {
@@ -181,9 +204,10 @@ async fn run_deploy(
                             continue;
                         }
                         eprintln!("easyenclave: post-deploy exec: {}", cmd.join(" "));
-                        match container::exec(&app_name, cmd).await {
+                        match container::exec(&container_id, cmd).await {
                             Ok((code, stdout, stderr)) => {
                                 if code != 0 {
+                                    let _ = container::stop(&container_id).await;
                                     eprintln!(
                                         "easyenclave: post-deploy cmd failed (exit {}): {}{}",
                                         code,
@@ -210,6 +234,7 @@ async fn run_deploy(
                                 }
                             }
                             Err(e) => {
+                                let _ = container::stop(&container_id).await;
                                 set_deploy_failed(
                                     &deployments,
                                     &dep_id,
@@ -243,8 +268,11 @@ async fn run_deploy(
                 drop(deps);
 
                 // Wait for process in background
+                let deployments_for_wait = deployments.clone();
+                let dep_id_for_wait = dep_id.clone();
                 tokio::spawn(async move {
-                    let _ = child.wait().await;
+                    let outcome = child.wait().await;
+                    record_process_exit(&deployments_for_wait, &dep_id_for_wait, outcome).await;
                 });
             }
             Err(e) => {
@@ -263,6 +291,62 @@ async fn set_deploy_failed(deployments: &Deployments, dep_id: &str, error: &str)
         info.status = "failed".into();
         info.error_message = Some(error.to_string());
     }
+}
+
+async fn record_process_exit(
+    deployments: &Deployments,
+    dep_id: &str,
+    outcome: Result<std::process::ExitStatus, std::io::Error>,
+) {
+    let (status, error_message) = match outcome {
+        Ok(exit_status) if exit_status.success() => ("exited", None),
+        Ok(exit_status) => (
+            "failed",
+            Some(format!("process exited with status {exit_status}")),
+        ),
+        Err(e) => ("failed", Some(format!("wait failed: {e}"))),
+    };
+
+    let mut deps = deployments.lock().await;
+    if let Some(info) = deps.get_mut(dep_id) {
+        if info.status == "running" {
+            info.pid = None;
+            info.status = status.to_string();
+            info.error_message = error_message;
+        }
+    }
+}
+
+fn spawn_container_monitor(deployments: Deployments, dep_id: String, container_id: String) {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+            let should_stop = {
+                let deps = deployments.lock().await;
+                match deps.get(&dep_id) {
+                    Some(info) => {
+                        info.status != "running"
+                            || info.container_id.as_deref() != Some(container_id.as_str())
+                    }
+                    None => true,
+                }
+            };
+            if should_stop {
+                break;
+            }
+
+            if !container::is_running(&container_id).await {
+                let mut deps = deployments.lock().await;
+                if let Some(info) = deps.get_mut(&dep_id) {
+                    if info.status == "running" {
+                        info.status = "exited".into();
+                    }
+                }
+                break;
+            }
+        }
+    });
 }
 
 // ── Stop ─────────────────────────────────────────────────────────────────────
@@ -306,5 +390,46 @@ pub async fn stop_all(deployments: &Deployments) {
         if let Err(e) = execute_stop(deployments, &id).await {
             eprintln!("easyenclave: stop {id}: {e}");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DeployRequest;
+
+    #[test]
+    fn deploy_request_requires_image_or_command() {
+        let err = DeployRequest {
+            cmd: Vec::new(),
+            image: None,
+            env: None,
+            volumes: None,
+            app_name: None,
+            tty: false,
+            post_deploy: None,
+            native: false,
+        }
+        .validate()
+        .unwrap_err();
+
+        assert_eq!(err, "either image or cmd must be specified");
+    }
+
+    #[test]
+    fn native_deployments_require_image() {
+        let err = DeployRequest {
+            cmd: vec!["/bin/demo".into()],
+            image: None,
+            env: None,
+            volumes: None,
+            app_name: None,
+            tty: false,
+            post_deploy: None,
+            native: true,
+        }
+        .validate()
+        .unwrap_err();
+
+        assert_eq!(err, "native deployments require an image");
     }
 }

--- a/www/index.html
+++ b/www/index.html
@@ -21,7 +21,7 @@
 
 <div class="hero">
   <h1>Run anything inside a <span class="g">hardware-sealed enclave</span></h1>
-  <p>Open-source runtime for Intel TDX confidential VMs. Runs as PID 1. Unix socket API. No networking in the enclave &mdash; minimal attack surface by design.</p>
+  <p>Open-source runtime for Intel TDX confidential VMs. Runs as PID 1. Unix socket API. No HTTP control plane in the enclave &mdash; minimal attack surface by design.</p>
   <div class="btns">
     <a href="#start" class="btn btn-g">Get Started</a>
     <a href="https://github.com/easyenclave/easyenclave" class="btn btn-o">View on GitHub</a>
@@ -35,7 +35,7 @@
     <div class="grid">
       <div class="card"><div class="ic">&#x1f510;</div><h3>PID 1 Runtime</h3><p>Runs as the init process inside the sealed VM. Mounts filesystems, configures network, reaps zombies, manages the full workload lifecycle.</p></div>
       <div class="card"><div class="ic">&#x1f50c;</div><h3>Unix Socket API</h3><p>Newline-delimited JSON over <code>/var/lib/easyenclave/agent.sock</code>. Deploy, attest, exec, monitor &mdash; all through one socket. No HTTP server in the enclave.</p></div>
-      <div class="card"><div class="ic">&#x1f6e1;</div><h3>No Networking</h3><p>The runtime itself has zero networking code. Workloads handle their own connectivity. Minimal attack surface &mdash; the enclave boundary is tight.</p></div>
+      <div class="card"><div class="ic">&#x1f6e1;</div><h3>No HTTP Surface</h3><p>The control plane stays on a local unix socket. Boot networking and image pulls still work, but there is no inbound HTTP API to expose inside the enclave.</p></div>
       <div class="card"><div class="ic">&#x2705;</div><h3>TDX Attestation</h3><p>Generate cryptographic quotes via configfs-tsm. Prove your code is running unmodified on real TDX hardware. Supports nonce-based fresh attestation.</p></div>
       <div class="card"><div class="ic">&#x1f433;</div><h3>Containers + Processes</h3><p>Deploy OCI containers (pulled and run directly by a Rust-native runtime &mdash; no podman, no docker daemon) or bare processes. Post-deploy exec commands run inside containers after start. Same API for both.</p></div>
       <div class="card"><div class="ic">&#x1f4dc;</div><h3>MIT Open Source</h3><p>Read every line. Audit every build. The enclave runtime is fully open, fully auditable. Built for production confidential computing workloads.</p></div>
@@ -91,7 +91,7 @@
       <div class="ae"><div class="l">deploy</div><pre><span class="k">&rarr;</span> {"<span class="k">method</span>":"<span class="s">deploy</span>","<span class="k">image</span>":"<span class="s">ghcr.io/org/app:latest</span>",
     "<span class="k">app_name</span>":"<span class="s">myapp</span>"}
 <span class="k">&larr;</span> {"<span class="k">ok</span>":true,"<span class="k">id</span>":"<span class="s">abc123</span>","<span class="k">status</span>":"<span class="s">deploying</span>"}</pre></div>
-      <div class="ae"><div class="l">attest</div><pre><span class="k">&rarr;</span> {"<span class="k">method</span>":"<span class="s">attest</span>","<span class="k">nonce</span>":"<span class="s">deadbeef</span>"}
+      <div class="ae"><div class="l">attest</div><pre><span class="k">&rarr;</span> {"<span class="k">method</span>":"<span class="s">attest</span>","<span class="k">nonce</span>":"<span class="s">&lt;base64 nonce&gt;</span>"}
 <span class="k">&larr;</span> {"<span class="k">ok</span>":true,"<span class="k">quote_b64</span>":"<span class="s">AQAAAA...</span>"}</pre></div>
       <div class="ae"><div class="l">exec</div><pre><span class="k">&rarr;</span> {"<span class="k">method</span>":"<span class="s">exec</span>","<span class="k">cmd</span>":["<span class="s">uname</span>","<span class="s">-a</span>"]}
 <span class="k">&larr;</span> {"<span class="k">ok</span>":true,"<span class="k">exit_code</span>":0,"<span class="k">stdout</span>":"<span class="s">Linux...</span>"}</pre></div>


### PR DESCRIPTION
## Summary
- harden native workload execution around single-static-binary OCI extraction and better deploy/process tracking
- add a public scratch-based ee-smoke-admin image for native CI coverage
- simplify the image workflow so PRs smoke-test temporary images and main publishes only after release-candidate validation

## Testing
- cargo test
- cargo test --bin ee-smoke-admin
- bash -n .github/scripts/smoke_test_gcp_vm.sh
- python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/image.yml")); print("ok")'