### PR TITLE
feat(image): per-target build profiles (gcp, local-tdx)

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Compute measurements
         id: meta
         run: |
-          cd image/output
+          cd image/output/gcp
           SHA12=$(echo "${{ github.sha }}" | cut -c1-12)
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
@@ -103,11 +103,11 @@ jobs:
           mv easyenclave.efi "easyenclave-${SHA12}.efi"
           mv easyenclave.root.raw "easyenclave-${SHA12}.raw"
           mv easyenclave.qcow2 "easyenclave-${SHA12}.qcow2"
-          cp "easyenclave-${SHA12}.raw" disk.raw
-          tar -czf "easyenclave-${SHA12}-gcp.tar.gz" disk.raw
-          rm disk.raw
+          # mkimage.sh already produced easyenclave-gcp.tar.gz; just rename.
+          mv easyenclave-gcp.tar.gz "easyenclave-${SHA12}-gcp.tar.gz"
           cat > MEASUREMENTS.txt <<EOF
           commit: ${{ github.sha }}
+          target: gcp
           UKI sha256: ${UKI_SHA256}
           Disk sha256: ${ROOT_SHA256}
           EOF
@@ -116,11 +116,11 @@ jobs:
         with:
           name: easyenclave-image
           path: |
-            image/output/easyenclave-*.efi
-            image/output/easyenclave-*.raw
-            image/output/easyenclave-*.qcow2
-            image/output/easyenclave-*-gcp.tar.gz
-            image/output/MEASUREMENTS.txt
+            image/output/gcp/easyenclave-*.efi
+            image/output/gcp/easyenclave-*.raw
+            image/output/gcp/easyenclave-*.qcow2
+            image/output/gcp/easyenclave-*-gcp.tar.gz
+            image/output/gcp/MEASUREMENTS.txt
           retention-days: 7
 
   # ── Deploy, test, and release (one GCP auth) ─────────────────────
@@ -141,7 +141,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: easyenclave-image
-          path: image/output
+          path: image/output/gcp
 
       # ── Create staging image ─────────────────────────────────────
       - name: Create GCP image
@@ -153,7 +153,7 @@ jobs:
           IS_PR: ${{ github.event_name == 'pull_request' }}
         run: |
           ASSET_BASE="easyenclave-${SHA12}"
-          gcloud storage cp "image/output/${ASSET_BASE}-gcp.tar.gz" \
+          gcloud storage cp "image/output/gcp/${ASSET_BASE}-gcp.tar.gz" \
             "gs://${GCS_BUCKET}/${ASSET_BASE}-gcp.tar.gz"
 
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
@@ -327,7 +327,7 @@ jobs:
           SHA12: ${{ needs.build.outputs.sha12 }}
           UKI_SHA256: ${{ needs.build.outputs.uki_sha256 }}
         run: |
-          cd image/output
+          cd image/output/gcp
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
             GH_TAG="${TAG}"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,45 @@ Requires Intel TDX hardware (configfs-tsm) — refuses to start without it.
 
 Config: `/etc/easyenclave/config.json` or env vars (`EE_SOCKET_PATH`, `EE_DATA_DIR`, `EE_BOOT_WORKLOADS`).
 
+## Deployment targets
+
+Image builds are profile-driven. Each deployment target is a directory under `image/targets/<name>/` with a `profile.env` that supplies its module set, root strategy, kernel cmdline, output format, and default machine topology.
+
+| Target | Format | Root strategy | Use case |
+|--------|--------|---------------|----------|
+| `gcp` | GPT disk (raw + qcow2 + tar.gz) | ext4 label + optional dm-verity | GCP TDX compute images (default) |
+| `local-tdx` | hybrid ISO with embedded ESP | iso9660 + squashfs + tmpfs overlay | Local QEMU/OVMF TDX boot for dev iteration |
+
+Build:
+
+```bash
+cd image
+make build                   # defaults to TARGET=gcp
+make build TARGET=local-tdx  # hybrid ISO for local TDX
+```
+
+Run locally:
+
+```bash
+bash image/test-local.sh [agent.env]        # gcp artifacts, direct-kernel, fastest dev loop
+bash image/run-local-tdx.sh [agent.env]     # local-tdx ISO, full OVMF+TDX boot chain
+```
+
+### Adding a new target
+
+1. `mkdir image/targets/<name> && $EDITOR image/targets/<name>/profile.env` (copy from an existing profile, tweak `TARGET_INITRD_MODULES` / `TARGET_CMDLINE` / `TARGET_FORMAT`).
+2. If you need a new root acquisition strategy, add `image/init-templates/<name>.sh` — it becomes the `/init` inside the initrd.
+3. `make build TARGET=<name>`.
+
+### Attestation across targets
+
+TDX MRTD and RTMR values **differ per target**, and differ again per launch site:
+
+- **MRTD** is derived from TDVF binary + memory size + vCPU topology. Local TDVF ≠ GCP's TDVF; `-m 4G -smp 2` locally ≠ `c3-standard-4` on GCP.
+- **RTMRs** depend on UKI bytes (each target's UKI embeds a different initrd and cmdline).
+
+Don't cross-verify a local quote against a GCP measurement. Treat local-tdx as a dev convenience, not a production-attestation-equivalent artifact.
+
 ## Architecture
 
 ```

--- a/image/Makefile
+++ b/image/Makefile
@@ -1,75 +1,80 @@
 # EasyEnclave VM Image Build
 #
-# Builds a bootable TDX VM image with easyenclave as PID 1.
-# Boots via Unified Kernel Image (UKI): kernel + initrd + cmdline in one
-# EFI binary. No bootloader. One file = one measurement.
+# Per-target image builds. Each target is a directory under targets/
+# supplying a profile.env that drives modules, cmdline, root strategy,
+# and output format.
+#
+# Boot chain (all targets):
+#   UEFI firmware → ESP/EFI/BOOT/BOOTX64.EFI (UKI) → kernel + initrd
+#                 → our init script → switch_root → easyenclave (PID 1)
 #
 # Workflow:
-#   1. mkosi Format=directory → produces populated rootfs tree
-#   2. mkfs.ext4 -d → packs the tree into an ext4 image
-#   3. mkinitrd.sh → builds minimal initrd with nvme+dm-verity modules
-#   4. ukify → builds UKI from host kernel + initrd + cmdline
-#   5. assemble-disk.sh → GPT disk with ESP (UKI) + root partitions
-#
-# We use Format=directory because Format=disk has a bug where the split
-# partition artifacts come out empty. Assembling the disk manually also
-# gives us full control over partition layout.
-#
-# TODO: add dm-verity back once base boot works.
+#   1. cargo build --release                     (shared across targets)
+#   2. mkosi Format=directory → rootfs tree      (shared)
+#   3. copy host kernel                          (shared)
+#   4. mkinitrd.sh <...> <profile>               (per-target modules + init template)
+#   5. ukify → UKI                               (per-target cmdline)
+#   6. mkimage.sh <profile>                      (per-target format: disk or iso)
 #
 # Prerequisites: mkosi 25+, cargo, busybox-static, e2fsprogs, mtools,
-#   systemd-boot-efi (for the EFI stub), systemd-ukify
+#   systemd-boot-efi (for the EFI stub), systemd-ukify,
+#   xorriso + squashfs-tools (for iso targets),
+#   qemu-utils (for qcow2)
+#
 # Usage:
-#   make build    - Build the image
-#   make clean    - Remove build artifacts
+#   make build                    # default TARGET=gcp
+#   make build TARGET=local-tdx   # hybrid ISO for local TDX boot
+#   make clean                    # clean just the current TARGET's output
+#   make clean-all                # clean output/ entirely
 
 REPO_ROOT := ..
 EXTRA_BIN := mkosi.extra/usr/local/bin
-OUTPUT_DIR := output
 EE_BIN := $(REPO_ROOT)/target/release/easyenclave
 EFI_STUB := /usr/lib/systemd/boot/efi/linuxx64.efi.stub
 KVER ?= $(shell uname -r)
 
-.PHONY: build clean
+TARGET ?= gcp
+OUTPUT_DIR := output/$(TARGET)
+PROFILE := targets/$(TARGET)/profile.env
+ROOTFS_DIR := $(OUTPUT_DIR)/easyenclave.rootfs
+
+.PHONY: build clean clean-all
 
 build: $(EXTRA_BIN)/easyenclave
-	chmod +x mkosi.postinst.chroot mkosi.finalize mkinitrd.sh assemble-disk.sh
+	@[ -f $(PROFILE) ] || { echo "Unknown TARGET=$(TARGET). Available: $$(ls targets/ 2>/dev/null)"; exit 1; }
+	chmod +x mkosi.postinst.chroot mkosi.finalize mkinitrd.sh mkimage.sh assemble-disk.sh lib/mkesp.sh
 	mkdir -p $(OUTPUT_DIR)
+	@echo ""
+	@echo "=== Building target: $(TARGET) ==="
+	@cat $(PROFILE) | sed 's/^/  /'
+	@echo ""
 	# 1. Build rootfs as a directory (Format=disk has a bug where the split
 	#    partition artifact is empty — directory output is populated correctly).
+	sudo rm -rf easyenclave
 	sudo mkosi build --force --format directory
 	sudo du -sh easyenclave/
-	# 2. Pack the directory into a plain ext4 image.
-	#    256MB is enough for ~81MB of content with room for logs/state.
-	rm -f $(OUTPUT_DIR)/rootfs.img
-	dd if=/dev/zero of=$(OUTPUT_DIR)/rootfs.img bs=1M count=256 status=none
-	sudo mkfs.ext4 -F -L root -d easyenclave $(OUTPUT_DIR)/rootfs.img 2>&1 | tail -3
-	# 3. Kernel cmdline: resolve root by label so the same UKI works on
-	#    GCP (nvme0n1p2) and local libvirt (vda2) — the initrd calls
-	#    `findfs LABEL=root` to get the device path at runtime.
-	echo "root=LABEL=root console=ttyS0,115200" > $(OUTPUT_DIR)/easyenclave.cmdline
-	# 4. Minimal initrd (nvme + dm-verity + deps via modprobe)
-	sudo bash mkinitrd.sh $(OUTPUT_DIR)/easyenclave.initrd $(KVER)
-	# 5. Host kernel
+	# 2. Move the populated rootfs under the target's output dir so concurrent
+	#    target builds don't step on each other.
+	sudo rm -rf $(ROOTFS_DIR)
+	sudo mv easyenclave $(ROOTFS_DIR)
+	# 3. Per-target kernel cmdline.
+	. $(PROFILE); echo "$$TARGET_CMDLINE" > $(OUTPUT_DIR)/easyenclave.cmdline
+	# 4. Per-target initrd (profile-driven modules + init template).
+	sudo bash mkinitrd.sh $(OUTPUT_DIR)/easyenclave.initrd $(KVER) $(PROFILE)
+	# 5. Host kernel.
 	sudo cp /boot/vmlinuz-$(KVER) $(OUTPUT_DIR)/easyenclave.vmlinuz
 	sudo chmod 644 $(OUTPUT_DIR)/easyenclave.vmlinuz
-	# 6. Build UKI
+	# 6. Build UKI.
 	ukify build \
 		--stub $(EFI_STUB) \
 		--linux $(OUTPUT_DIR)/easyenclave.vmlinuz \
 		--initrd $(OUTPUT_DIR)/easyenclave.initrd \
 		--cmdline @$(OUTPUT_DIR)/easyenclave.cmdline \
 		--output $(OUTPUT_DIR)/easyenclave.efi
-	# 7. Assemble bootable GPT disk: ESP (with UKI) + rootfs
-	bash assemble-disk.sh $(OUTPUT_DIR)
-	# 8. Convert raw disk to compressed qcow2 for QEMU/libvirt users.
-	#    qcow2 is the standard QEMU format: smaller on disk, supports
-	#    snapshots, copy-on-write, etc.
-	qemu-img convert -f raw -O qcow2 -c \
-		$(OUTPUT_DIR)/easyenclave.root.raw \
-		$(OUTPUT_DIR)/easyenclave.qcow2
+	# 7. Per-target final image (disk or iso).
+	bash mkimage.sh $(PROFILE) $(OUTPUT_DIR)
 	@echo ""
-	@echo "Build complete:"
+	@echo "=== Build complete ($(TARGET)) ==="
 	@ls -lh $(OUTPUT_DIR)/ 2>/dev/null || true
 
 $(EE_BIN):
@@ -85,5 +90,10 @@ clean:
 	# rest of mkosi.extra (e.g. usr/share/udhcpc/default.script) is
 	# tracked content and must survive `make clean`.
 	sudo rm -f $(EXTRA_BIN)/easyenclave
-	sudo rm -rf $(OUTPUT_DIR) easyenclave easyenclave.raw easyenclave.root-*.raw easyenclave.vmlinuz easyenclave.initrd easyenclave.efi easyenclave.manifest easyenclave-image.tar.gz disk.raw
+	sudo rm -rf $(OUTPUT_DIR) easyenclave
+	sudo mkosi clean 2>/dev/null || true
+
+clean-all:
+	sudo rm -f $(EXTRA_BIN)/easyenclave
+	sudo rm -rf output easyenclave
 	sudo mkosi clean 2>/dev/null || true

--- a/image/assemble-disk.sh
+++ b/image/assemble-disk.sh
@@ -13,20 +13,20 @@
 set -euo pipefail
 
 OUTPUT_DIR="${1:-.}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 UKI="${OUTPUT_DIR}/easyenclave.efi"
 ROOT_IMG="${OUTPUT_DIR}/rootfs.img"
 DISK="${OUTPUT_DIR}/easyenclave.root.raw"
+ESP_SIZE=64  # MB
 
 [ -f "$UKI" ] || { echo "No UKI at $UKI"; exit 1; }
 [ -f "$ROOT_IMG" ] || { echo "No rootfs at $ROOT_IMG"; exit 1; }
 
-# ESP with the UKI as the default boot entry
-ESP_SIZE=64  # MB
+# ESP with the UKI as the default boot entry (shared helper — also
+# used by the iso target for El Torito).
 ESP_IMG=$(mktemp)
-dd if=/dev/zero of="$ESP_IMG" bs=1M count=$ESP_SIZE 2>/dev/null
-mkfs.vfat -F 32 "$ESP_IMG" >/dev/null
-mmd -i "$ESP_IMG" ::EFI ::EFI/BOOT
-mcopy -i "$ESP_IMG" "$UKI" ::EFI/BOOT/BOOTX64.EFI
+trap 'rm -f "$ESP_IMG"' EXIT
+bash "$SCRIPT_DIR/lib/mkesp.sh" "$UKI" "$ESP_IMG" $ESP_SIZE
 
 # Partition layout
 ESP_BYTES=$((ESP_SIZE * 1024 * 1024))
@@ -50,8 +50,6 @@ EOF
 # Write partition contents
 dd if="$ESP_IMG" of="$DISK" bs=512 seek=$ESP_START conv=notrunc 2>/dev/null
 dd if="$ROOT_IMG" of="$DISK" bs=512 seek=$ROOT_START conv=notrunc 2>/dev/null
-
-rm -f "$ESP_IMG"
 
 SIZE=$(du -h "$DISK" | cut -f1)
 echo "Bootable disk assembled: $DISK ($SIZE)"

--- a/image/init-templates/ext4-label.sh
+++ b/image/init-templates/ext4-label.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+# Minimal init: load modules, set up dm-verity, mount root, switch_root.
+#
+# Root acquisition: resolve `root=LABEL=...` via findfs, mount the ext4
+# rootfs read-only (optionally via dm-verity).
+
+mount -t proc proc /proc
+mount -t sysfs sysfs /sys
+mount -t devtmpfs devtmpfs /dev
+
+# Parse kernel cmdline
+ROOTHASH=""
+ROOT_DATA=""
+ROOT_HASH=""
+for param in $(cat /proc/cmdline); do
+    case "$param" in
+        roothash=*) ROOTHASH="${param#roothash=}" ;;
+        systemd.verity_root_data=*) ROOT_DATA="${param#systemd.verity_root_data=}" ;;
+        systemd.verity_root_hash=*) ROOT_HASH="${param#systemd.verity_root_hash=}" ;;
+        root=*) ROOT_DATA="${param#root=}" ;;
+    esac
+done
+
+# Load kernel modules via modprobe — uses modules.dep to resolve transitive
+# deps automatically. Kernel built-ins (ext4, dm-mod, virtio_blk, crc32c)
+# are already present. If a target module is compiled in rather than
+# shipped as .ko (e.g. Ubuntu's stock kernels with CONFIG_TDX_GUEST_DRIVER=y),
+# busybox modprobe returns "not found"; we tolerate that because the
+# driver is still in the kernel. If it's genuinely missing, easyenclave's
+# attestation backend detection will fail later with a clearer error.
+modprobe dm-verity 2>/dev/null || echo "note: dm-verity not loaded (may be built-in)"
+modprobe nvme 2>/dev/null      || echo "note: nvme not loaded (may be built-in or N/A)"
+modprobe tdx_guest 2>/dev/null || echo "note: tdx_guest not loaded (may be built-in)"
+modprobe tsm_report 2>/dev/null || echo "note: tsm_report not loaded (may be built-in)"
+# Network drivers — needed BEFORE switch_root so /sys/class/net has a
+# non-lo interface by the time easyenclave's init.rs reads it to decide
+# which interface to DHCP. Without this, easyenclave sees only "lo",
+# skips the entire `if let Some(iface)` block, never runs udhcpc, never
+# fetches GCE metadata, never deploys workloads — the VM silently
+# reaches "listening on" with no network. GCP c3 machines use gVNIC
+# (gve driver); other types use virtio-net.
+modprobe gve 2>/dev/null       || echo "note: gve not loaded (not a c3/gvnic host?)"
+modprobe virtio_net 2>/dev/null || echo "note: virtio_net not loaded (not a virtio host?)"
+
+# Resolve LABEL=/UUID= to a device path. The cmdline uses
+# `root=LABEL=root` so one UKI boots on both GCP (nvme0n1p2) and
+# libvirt/qemu (vda2) — the kernel labels the ext4 rootfs with
+# "root" at build time (see image/Makefile mkfs.ext4 -L root).
+case "$ROOT_DATA" in
+    LABEL=*|UUID=*)
+        for i in $(seq 1 30); do
+            RESOLVED=$(findfs "$ROOT_DATA" 2>/dev/null || true)
+            [ -n "$RESOLVED" ] && [ -e "$RESOLVED" ] && { ROOT_DATA="$RESOLVED"; break; }
+            sleep 1
+        done
+        ;;
+    *)
+        # Explicit device path — just wait for it.
+        for i in $(seq 1 30); do
+            [ -e "$ROOT_DATA" ] && break
+            sleep 1
+        done
+        ;;
+esac
+echo "Resolved root to $ROOT_DATA"
+[ -e "$ROOT_DATA" ] || { echo "FATAL: $ROOT_DATA not found after 30s"; ls /dev/nvme* /dev/vd* /dev/sd* 2>/dev/null; exec /bin/sh; }
+
+if [ -n "$ROOTHASH" ] && [ -n "$ROOT_DATA" ] && [ -n "$ROOT_HASH" ] && command -v veritysetup >/dev/null; then
+    # dm-verity: cryptographically verified root
+    veritysetup open "$ROOT_DATA" verity-root "$ROOT_HASH" "$ROOTHASH" || {
+        echo "FATAL: dm-verity setup failed"
+        exec /bin/sh
+    }
+    mount -o ro /dev/mapper/verity-root /mnt/root
+elif [ -n "$ROOT_DATA" ]; then
+    # Fallback: direct mount (no verity)
+    mount -o ro "$ROOT_DATA" /mnt/root
+else
+    echo "FATAL: no root= or roothash= in cmdline"
+    exec /bin/sh
+fi
+
+# Switch to the real root and exec easyenclave
+umount /proc /sys
+exec switch_root /mnt/root /sbin/init

--- a/image/init-templates/squashfs-overlay.sh
+++ b/image/init-templates/squashfs-overlay.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# Minimal init: load modules, find ISO, loop-mount squashfs, overlay on
+# tmpfs for writable upper layer, switch_root.
+#
+# Root acquisition: iso9660 from a CDROM device, squashfs file inside it,
+# overlayfs(tmpfs upper, squashfs lower).
+
+mount -t proc proc /proc
+mount -t sysfs sysfs /sys
+mount -t devtmpfs devtmpfs /dev
+
+# Load modules. Storage + network + iso/squashfs/overlay. Tolerate
+# built-ins silently (modprobe prints "not found" when the driver is
+# compiled in, which is fine — the capability is still present).
+for m in tdx_guest tsm_report virtio_blk virtio_net virtio_pci virtio_scsi sr_mod cdrom isofs loop squashfs overlay; do
+    modprobe "$m" 2>/dev/null || echo "note: $m not loaded (may be built-in)"
+done
+
+# Find the CDROM holding rootfs.squashfs. Try common names in order; the
+# device ordering depends on host config (local QEMU tends to /dev/sr0,
+# virtio-scsi hosts may see /dev/sr1 first).
+mkdir -p /mnt/iso /mnt/lower /mnt/upper /mnt/work /mnt/root
+ISO_DEV=""
+for i in $(seq 1 30); do
+    for dev in /dev/sr0 /dev/sr1 /dev/cdrom /dev/vda /dev/vdb; do
+        [ -e "$dev" ] || continue
+        if mount -t iso9660 -o ro "$dev" /mnt/iso 2>/dev/null; then
+            if [ -f /mnt/iso/rootfs.squashfs ]; then
+                ISO_DEV="$dev"
+                break 2
+            fi
+            umount /mnt/iso 2>/dev/null || true
+        fi
+    done
+    sleep 1
+done
+[ -n "$ISO_DEV" ] || { echo "FATAL: no iso9660 with rootfs.squashfs"; ls /dev/sr* /dev/vd* 2>/dev/null; exec /bin/sh; }
+echo "Resolved iso to $ISO_DEV"
+
+# Loop-mount the sealed rootfs read-only.
+mount -t squashfs -o loop,ro /mnt/iso/rootfs.squashfs /mnt/lower || {
+    echo "FATAL: squashfs mount failed"
+    exec /bin/sh
+}
+
+# Writable overlay: lower = sealed squashfs, upper = tmpfs.
+# Result: the rootfs looks writable but nothing persists across reboots —
+# which is the intended sealed-VM behavior.
+mount -t tmpfs tmpfs /mnt/upper || true
+mkdir -p /mnt/upper/u /mnt/upper/w
+mount -t overlay overlay \
+    -o "lowerdir=/mnt/lower,upperdir=/mnt/upper/u,workdir=/mnt/upper/w" \
+    /mnt/root || {
+    echo "FATAL: overlay mount failed"
+    exec /bin/sh
+}
+
+# Carry the iso9660 mount forward so the running system can still read
+# rootfs.squashfs (debugging) and any secondary data the image may add.
+mkdir -p /mnt/root/mnt/iso
+mount --move /mnt/iso /mnt/root/mnt/iso 2>/dev/null || true
+
+umount /proc /sys
+exec switch_root /mnt/root /sbin/init

--- a/image/lib/mkesp.sh
+++ b/image/lib/mkesp.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Build a FAT32 ESP image containing the given UKI at EFI/BOOT/BOOTX64.EFI.
+#
+# Usage: mkesp.sh <uki-path> <out-image-path> [size-mb]
+#
+# Shared by assemble-disk.sh (GCP disk ESP) and mkimage.sh (ISO El Torito).
+
+set -euo pipefail
+
+UKI="${1:?Usage: mkesp.sh <uki> <out> [size-mb]}"
+OUT="${2:?Usage: mkesp.sh <uki> <out> [size-mb]}"
+SIZE_MB="${3:-64}"
+
+[ -f "$UKI" ] || { echo "mkesp: no UKI at $UKI"; exit 1; }
+
+dd if=/dev/zero of="$OUT" bs=1M count="$SIZE_MB" status=none
+mkfs.vfat -F 32 "$OUT" >/dev/null
+mmd -i "$OUT" ::EFI ::EFI/BOOT
+mcopy -i "$OUT" "$UKI" ::EFI/BOOT/BOOTX64.EFI

--- a/image/mkimage.sh
+++ b/image/mkimage.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Produce the target's final bootable image(s) from the built artifacts.
+#
+# Usage: mkimage.sh <profile-env> <output-dir>
+#
+# Inputs expected in <output-dir>:
+#   easyenclave.efi        (UKI; always required)
+#   easyenclave.rootfs/    (mkosi-populated directory; for disk format)
+#
+# Outputs depend on TARGET_FORMAT:
+#   disk → rootfs.img (ext4), easyenclave.root.raw (GPT disk),
+#          easyenclave.qcow2 (if `qcow2` in TARGET_OUTPUTS),
+#          easyenclave-<sha12>-gcp.tar.gz (if `gcp-tar.gz` in TARGET_OUTPUTS)
+#   iso  → rootfs.squashfs, easyenclave.iso
+set -euo pipefail
+
+PROFILE="${1:?Usage: mkimage.sh <profile-env> <output-dir>}"
+OUT="${2:?Usage: mkimage.sh <profile-env> <output-dir>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+[ -f "$PROFILE" ] || { echo "mkimage: profile $PROFILE not found"; exit 1; }
+# shellcheck disable=SC1090
+. "$PROFILE"
+
+UKI="$OUT/easyenclave.efi"
+ROOTFS_DIR="$OUT/easyenclave.rootfs"
+[ -f "$UKI" ] || { echo "mkimage: no UKI at $UKI"; exit 1; }
+[ -d "$ROOTFS_DIR" ] || { echo "mkimage: no rootfs tree at $ROOTFS_DIR"; exit 1; }
+
+echo "mkimage: format=$TARGET_FORMAT strategy=$TARGET_ROOT_STRATEGY"
+
+case "$TARGET_FORMAT" in
+    disk)
+        # 1. Pack the rootfs tree into a plain ext4 image.
+        ROOTFS_IMG="$OUT/rootfs.img"
+        rm -f "$ROOTFS_IMG"
+        dd if=/dev/zero of="$ROOTFS_IMG" bs=1M count=256 status=none
+        sudo mkfs.ext4 -F -L root -d "$ROOTFS_DIR" "$ROOTFS_IMG" 2>&1 | tail -3
+
+        # 2. Assemble GPT disk: ESP (with UKI) + rootfs.
+        bash "$SCRIPT_DIR/assemble-disk.sh" "$OUT"
+
+        # 3. Derived formats.
+        case " $TARGET_OUTPUTS " in
+            *" qcow2 "*)
+                qemu-img convert -f raw -O qcow2 -c \
+                    "$OUT/easyenclave.root.raw" \
+                    "$OUT/easyenclave.qcow2"
+                ;;
+        esac
+        case " $TARGET_OUTPUTS " in
+            *" gcp-tar.gz "*)
+                # Name is chosen by the caller (CI packages it with a sha12
+                # suffix). mkimage just produces the canonical disk.raw +
+                # tar.gz pair.
+                cp "$OUT/easyenclave.root.raw" "$OUT/disk.raw"
+                tar -czf "$OUT/easyenclave-gcp.tar.gz" -C "$OUT" disk.raw
+                rm -f "$OUT/disk.raw"
+                ;;
+        esac
+        ;;
+
+    iso)
+        # 1. Squashfs of the rootfs. zstd is a good balance of size/speed;
+        # xz would be ~10-15% smaller but much slower to build.
+        SQUASHFS="$OUT/rootfs.squashfs"
+        rm -f "$SQUASHFS"
+        sudo mksquashfs "$ROOTFS_DIR" "$SQUASHFS" -comp zstd -quiet
+        sudo chown "$(id -u):$(id -g)" "$SQUASHFS"
+
+        # 2. ESP image with the UKI as the El Torito EFI boot entry.
+        ESP_IMG=$(mktemp)
+        trap 'rm -f "$ESP_IMG"' EXIT
+        bash "$SCRIPT_DIR/lib/mkesp.sh" "$UKI" "$ESP_IMG" 48
+
+        # 3. Hybrid ISO with an embedded ESP partition. xorriso's
+        #    -append_partition + -isohybrid-gpt-basdat produces an ISO
+        #    that UEFI firmware boots directly via its El Torito EFI
+        #    entry, while iso9660 still contains our rootfs.squashfs.
+        STAGE=$(mktemp -d)
+        trap 'rm -rf "$STAGE"; rm -f "$ESP_IMG"' EXIT
+        cp "$SQUASHFS" "$STAGE/rootfs.squashfs"
+
+        xorriso -as mkisofs \
+            -V EE_ISO \
+            -o "$OUT/easyenclave.iso" \
+            -isohybrid-gpt-basdat \
+            -partition_offset 16 \
+            -append_partition 2 0xef "$ESP_IMG" \
+            -e --interval:appended_partition_2:all:: \
+            -no-emul-boot \
+            -iso-level 3 \
+            -joliet \
+            -rational-rock \
+            "$STAGE"
+
+        SIZE=$(du -h "$OUT/easyenclave.iso" | cut -f1)
+        echo "ISO built: $OUT/easyenclave.iso ($SIZE)"
+        ;;
+
+    *)
+        echo "mkimage: unknown TARGET_FORMAT=$TARGET_FORMAT"
+        exit 1
+        ;;
+esac

--- a/image/mkinitrd.sh
+++ b/image/mkinitrd.sh
@@ -1,15 +1,34 @@
 #!/bin/bash
-# Build a minimal initrd for easyenclave TDX VMs.
-# Just enough to: load dm-verity/virtio modules, mount root, exec /sbin/init.
+# Build a minimal initrd for easyenclave VMs, profile-driven.
+# Just enough to: load the target's modules, mount its root, switch_root.
 # ~2-5MB instead of mkosi's default ~300MB systemd initrd.
+#
+# Usage: mkinitrd.sh <outfile> <kernel-version> <profile-env>
+#
+# The profile env file (e.g. image/targets/gcp/profile.env) supplies:
+#   TARGET_INITRD_MODULES   - space-separated module names to pull in
+#   TARGET_ROOT_STRATEGY    - name of the init template under init-templates/
 set -euo pipefail
 
-OUTFILE="${1:-initrd.cpio.gz}"
-KVER="${2:?Usage: mkinitrd.sh <outfile> <kernel-version>}"
+OUTFILE="${1:?Usage: mkinitrd.sh <outfile> <kernel-version> <profile-env>}"
+KVER="${2:?Usage: mkinitrd.sh <outfile> <kernel-version> <profile-env>}"
+PROFILE="${3:?Usage: mkinitrd.sh <outfile> <kernel-version> <profile-env>}"
 MOD_SRC="/lib/modules/$KVER"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+[ -f "$PROFILE" ] || { echo "FATAL: profile $PROFILE not found"; exit 1; }
 [ -d "$MOD_SRC" ] || { echo "FATAL: $MOD_SRC not found"; exit 1; }
-echo "Building initrd for kernel $KVER (modules: $MOD_SRC)"
+
+# shellcheck disable=SC1090
+. "$PROFILE"
+
+INIT_TEMPLATE="$SCRIPT_DIR/init-templates/${TARGET_ROOT_STRATEGY}.sh"
+[ -f "$INIT_TEMPLATE" ] || { echo "FATAL: no init template for $TARGET_ROOT_STRATEGY at $INIT_TEMPLATE"; exit 1; }
+
+echo "Building initrd for kernel $KVER"
+echo "  profile:  $PROFILE"
+echo "  strategy: $TARGET_ROOT_STRATEGY"
+echo "  modules:  $TARGET_INITRD_MODULES"
 
 WORKDIR=$(mktemp -d)
 trap "rm -rf $WORKDIR" EXIT
@@ -27,7 +46,7 @@ fi
 chmod +x "$WORKDIR/bin/busybox"
 
 # Symlink essential commands
-for cmd in sh mount umount switch_root mkdir cat echo sleep modprobe insmod findfs ls; do
+for cmd in sh mount umount switch_root mkdir cat echo sleep modprobe insmod findfs ls losetup; do
     ln -s busybox "$WORKDIR/bin/$cmd"
 done
 
@@ -74,7 +93,7 @@ copy_mod() {
     esac
 }
 
-for top in dm-verity nvme tdx-guest tsm-report gve virtio_net; do
+for top in $TARGET_INITRD_MODULES; do
     deps=$(modprobe --show-depends --set-version "$KVER" "$top" 2>&1 || true)
     if ! echo "$deps" | grep -q '^insmod'; then
         echo "  $top: not available as a module on $KVER (built-in or absent)"
@@ -107,7 +126,9 @@ echo "=== modules.dep ==="
 cat "$MODDIR/modules.dep" 2>/dev/null || echo "(missing)"
 echo "==="
 
-# veritysetup for dm-verity (from cryptsetup-bin)
+# veritysetup for dm-verity (from cryptsetup-bin). Only meaningful for
+# strategies that use dm-verity (ext4-label does; squashfs-overlay
+# doesn't). Copying unconditionally adds ~200KB + libs; cheap insurance.
 if command -v veritysetup >/dev/null 2>&1; then
     cp "$(which veritysetup)" "$WORKDIR/sbin/"
     # Copy its library deps
@@ -118,91 +139,8 @@ if command -v veritysetup >/dev/null 2>&1; then
     done
 fi
 
-# Init script
-cat > "$WORKDIR/init" <<'INIT'
-#!/bin/sh
-# Minimal init: load modules, set up dm-verity, mount root, switch_root.
-
-mount -t proc proc /proc
-mount -t sysfs sysfs /sys
-mount -t devtmpfs devtmpfs /dev
-
-# Parse kernel cmdline
-ROOTHASH=""
-ROOT_DATA=""
-ROOT_HASH=""
-for param in $(cat /proc/cmdline); do
-    case "$param" in
-        roothash=*) ROOTHASH="${param#roothash=}" ;;
-        systemd.verity_root_data=*) ROOT_DATA="${param#systemd.verity_root_data=}" ;;
-        systemd.verity_root_hash=*) ROOT_HASH="${param#systemd.verity_root_hash=}" ;;
-        root=*) ROOT_DATA="${param#root=}" ;;
-    esac
-done
-
-# Load kernel modules via modprobe — uses modules.dep to resolve transitive
-# deps automatically. Kernel built-ins (ext4, dm-mod, virtio_blk, crc32c)
-# are already present. If a target module is compiled in rather than
-# shipped as .ko (e.g. Ubuntu's stock kernels with CONFIG_TDX_GUEST_DRIVER=y),
-# busybox modprobe returns "not found"; we tolerate that because the
-# driver is still in the kernel. If it's genuinely missing, easyenclave's
-# attestation backend detection will fail later with a clearer error.
-modprobe dm-verity 2>/dev/null || echo "note: dm-verity not loaded (may be built-in)"
-modprobe nvme 2>/dev/null      || echo "note: nvme not loaded (may be built-in or N/A)"
-modprobe tdx_guest 2>/dev/null || echo "note: tdx_guest not loaded (may be built-in)"
-modprobe tsm_report 2>/dev/null || echo "note: tsm_report not loaded (may be built-in)"
-# Network drivers — needed BEFORE switch_root so /sys/class/net has a
-# non-lo interface by the time easyenclave's init.rs reads it to decide
-# which interface to DHCP. Without this, easyenclave sees only "lo",
-# skips the entire `if let Some(iface)` block, never runs udhcpc, never
-# fetches GCE metadata, never deploys workloads — the VM silently
-# reaches "listening on" with no network. GCP c3 machines use gVNIC
-# (gve driver); other types use virtio-net.
-modprobe gve 2>/dev/null       || echo "note: gve not loaded (not a c3/gvnic host?)"
-modprobe virtio_net 2>/dev/null || echo "note: virtio_net not loaded (not a virtio host?)"
-
-# Resolve LABEL=/UUID= to a device path. The cmdline uses
-# `root=LABEL=root` so one UKI boots on both GCP (nvme0n1p2) and
-# libvirt/qemu (vda2) — the kernel labels the ext4 rootfs with
-# "root" at build time (see image/Makefile mkfs.ext4 -L root).
-case "$ROOT_DATA" in
-    LABEL=*|UUID=*)
-        for i in $(seq 1 30); do
-            RESOLVED=$(findfs "$ROOT_DATA" 2>/dev/null || true)
-            [ -n "$RESOLVED" ] && [ -e "$RESOLVED" ] && { ROOT_DATA="$RESOLVED"; break; }
-            sleep 1
-        done
-        ;;
-    *)
-        # Explicit device path — just wait for it.
-        for i in $(seq 1 30); do
-            [ -e "$ROOT_DATA" ] && break
-            sleep 1
-        done
-        ;;
-esac
-echo "Resolved root to $ROOT_DATA"
-[ -e "$ROOT_DATA" ] || { echo "FATAL: $ROOT_DATA not found after 30s"; ls /dev/nvme* /dev/vd* /dev/sd* 2>/dev/null; exec /bin/sh; }
-
-if [ -n "$ROOTHASH" ] && [ -n "$ROOT_DATA" ] && [ -n "$ROOT_HASH" ] && command -v veritysetup >/dev/null; then
-    # dm-verity: cryptographically verified root
-    veritysetup open "$ROOT_DATA" verity-root "$ROOT_HASH" "$ROOTHASH" || {
-        echo "FATAL: dm-verity setup failed"
-        exec /bin/sh
-    }
-    mount -o ro /dev/mapper/verity-root /mnt/root
-elif [ -n "$ROOT_DATA" ]; then
-    # Fallback: direct mount (no verity)
-    mount -o ro "$ROOT_DATA" /mnt/root
-else
-    echo "FATAL: no root= or roothash= in cmdline"
-    exec /bin/sh
-fi
-
-# Switch to the real root and exec easyenclave
-umount /proc /sys
-exec switch_root /mnt/root /sbin/init
-INIT
+# Install the profile-specified init template.
+cp "$INIT_TEMPLATE" "$WORKDIR/init"
 chmod +x "$WORKDIR/init"
 
 # Create the cpio archive

--- a/image/run-local-tdx.sh
+++ b/image/run-local-tdx.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Boot the local-tdx ISO under QEMU with OVMF + TDX.
+#
+# This is the full boot chain: OVMF firmware → UKI on embedded ESP →
+# kernel + initrd → squashfs+overlay init → easyenclave. Same path as
+# a production TDX launch, different TDVF binary and different machine
+# topology — the MRTD/RTMR values WILL differ from the GCP profile.
+#
+# Usage:
+#   bash image/run-local-tdx.sh [agent.env]
+#
+# If agent.env is supplied, a second iso9660 volume is attached — the
+# exact same config-disk plumbing easyenclave's init.rs already uses
+# on GCP (see src/init.rs), so local and cloud configs are loaded by
+# the same code path.
+#
+# Env knobs:
+#   EE_MEM       memory size (default from profile, TARGET_DEFAULT_MEM)
+#   EE_SMP       vCPU count (default from profile, TARGET_DEFAULT_VCPU)
+#   OVMF_CODE    firmware path (default /usr/share/OVMF/OVMF_CODE.fd)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROFILE="$SCRIPT_DIR/targets/local-tdx/profile.env"
+OUTPUT_DIR="$SCRIPT_DIR/output/local-tdx"
+ISO="$OUTPUT_DIR/easyenclave.iso"
+ENV_FILE="${1:-}"
+
+[ -f "$PROFILE" ] || { echo "Missing $PROFILE"; exit 1; }
+[ -f "$ISO" ] || { echo "Missing $ISO — run 'make build TARGET=local-tdx' first"; exit 1; }
+
+# shellcheck disable=SC1090
+. "$PROFILE"
+
+EE_MEM="${EE_MEM:-$TARGET_DEFAULT_MEM}"
+EE_SMP="${EE_SMP:-$TARGET_DEFAULT_VCPU}"
+OVMF_CODE="${OVMF_CODE:-/usr/share/OVMF/OVMF_CODE.fd}"
+
+# ── Prereqs ─────────────────────────────────────────────────────────
+command -v qemu-system-x86_64 >/dev/null || {
+    echo "qemu-system-x86_64 not found (apt install qemu-system-x86)"
+    exit 1
+}
+[ -f "$OVMF_CODE" ] || {
+    echo "OVMF firmware not found at $OVMF_CODE"
+    echo "  apt install ovmf         # generic UEFI firmware"
+    echo "  or set OVMF_CODE=/path/to/TDVF.fd for a TDX-enlightened build"
+    exit 1
+}
+
+TDX_SUPPORT=$(cat /sys/module/kvm_intel/parameters/tdx 2>/dev/null || echo "N")
+if [ "$TDX_SUPPORT" != "Y" ]; then
+    echo "WARNING: kvm_intel.tdx=$TDX_SUPPORT — booting without TDX."
+    echo "         Attestation will fail; everything else works."
+    TDX_FLAGS="-machine q35,kernel-irqchip=split"
+else
+    TDX_FLAGS="-machine q35,kernel-irqchip=split,confidential-guest-support=tdx -object tdx-guest,id=tdx"
+fi
+
+# ── Config disk (optional) ───────────────────────────────────────────
+CONFIG_DRIVE=""
+if [ -n "$ENV_FILE" ]; then
+    [ -f "$ENV_FILE" ] || { echo "agent.env not found: $ENV_FILE"; exit 1; }
+    command -v genisoimage >/dev/null || { echo "genisoimage not found (apt install genisoimage)"; exit 1; }
+    CONFIG_ISO=$(mktemp --suffix=.iso)
+    trap 'rm -f "$CONFIG_ISO"' EXIT
+    genisoimage -quiet -o "$CONFIG_ISO" -V CONFIG -r -J "$ENV_FILE"
+    CONFIG_DRIVE="-drive file=$CONFIG_ISO,if=virtio,format=raw,media=cdrom,readonly=on"
+    echo "Config ISO: $CONFIG_ISO (from $ENV_FILE)"
+fi
+
+# ── Boot ─────────────────────────────────────────────────────────────
+echo "Profile: local-tdx"
+echo "ISO:     $ISO"
+echo "OVMF:    $OVMF_CODE"
+echo "Memory:  $EE_MEM"
+echo "vCPU:    $EE_SMP"
+echo "TDX:     $TDX_SUPPORT"
+echo ""
+echo "Serial output below. Ctrl-A X to quit."
+echo "════════════════════════════════════════════════════════════════"
+
+# shellcheck disable=SC2086
+exec qemu-system-x86_64 \
+    -enable-kvm -cpu host -m "$EE_MEM" -smp "$EE_SMP" \
+    $TDX_FLAGS \
+    -drive if=pflash,format=raw,readonly=on,file="$OVMF_CODE" \
+    -cdrom "$ISO" \
+    $CONFIG_DRIVE \
+    -netdev user,id=n0 -device virtio-net-pci,netdev=n0 \
+    -serial mon:stdio \
+    -nographic

--- a/image/targets/gcp/profile.env
+++ b/image/targets/gcp/profile.env
@@ -1,0 +1,23 @@
+# GCP TDX VM target — sealed GPT disk with ext4 rootfs.
+#
+# Boot chain: UEFI (OVMF on GCP) → ESP/EFI/BOOT/BOOTX64.EFI (UKI) →
+# kernel + our initrd → findfs LABEL=root → mount ext4 → switch_root.
+
+TARGET_FORMAT=disk
+TARGET_ROOT_STRATEGY=ext4-label
+TARGET_CMDLINE="root=LABEL=root console=ttyS0,115200"
+
+# Modules shipped in the initrd. Built-ins on the host kernel are tolerated:
+# mkinitrd.sh copies whichever of these are available as .ko and falls back
+# silently when a driver is compiled in.
+TARGET_INITRD_MODULES="dm-verity nvme tdx-guest tsm-report gve virtio_net"
+
+# Artifacts produced. `disk` format always yields efi+raw+qcow2; `gcp-tar.gz`
+# is the GCE compute-image import format.
+TARGET_OUTPUTS="efi raw qcow2 gcp-tar.gz"
+
+# Informational — used by run-local-*.sh launchers and docs. MRTD is
+# influenced by memory + vCPU on the TDX host, so deploying at these
+# sizes keeps measurements reproducible.
+TARGET_DEFAULT_MEM=4G
+TARGET_DEFAULT_VCPU=2

--- a/image/targets/local-tdx/profile.env
+++ b/image/targets/local-tdx/profile.env
@@ -1,0 +1,23 @@
+# Local TDX VM target — hybrid ISO with squashfs rootfs + tmpfs overlay.
+#
+# Boot chain: OVMF (local TDVF) → ESP/EFI/BOOT/BOOTX64.EFI (UKI) →
+# kernel + our initrd → mount iso9660 → loop-mount rootfs.squashfs →
+# overlay on tmpfs → switch_root.
+#
+# MRTD/RTMR WILL differ from the gcp profile even with identical source
+# (different TDVF, different UKI, different memory/vCPU topology). Local
+# boots are a dev convenience, not an attested production artifact.
+
+TARGET_FORMAT=iso
+TARGET_ROOT_STRATEGY=squashfs-overlay
+TARGET_CMDLINE="console=ttyS0,115200 ee.boot=iso"
+
+# Modules needed to find and mount the ISO-resident squashfs.
+TARGET_INITRD_MODULES="tdx-guest tsm-report virtio_net virtio_blk virtio_pci virtio_scsi sr_mod cdrom isofs loop squashfs overlay"
+
+# Artifacts produced. `iso` format yields efi+iso (and by convention the
+# UKI the ISO embeds, useful for out-of-band measurement).
+TARGET_OUTPUTS="efi iso"
+
+TARGET_DEFAULT_MEM=4G
+TARGET_DEFAULT_VCPU=2

--- a/image/test-local.sh
+++ b/image/test-local.sh
@@ -22,7 +22,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-OUTPUT_DIR="$SCRIPT_DIR/output"
+# Non-TDX / direct-kernel dev loop — always uses the gcp target's
+# artifacts (ext4 rootfs in a qcow2). Local-TDX ISO boot lives in
+# run-local-tdx.sh.
+OUTPUT_DIR="$SCRIPT_DIR/output/gcp"
 ENV_FILE="${1:-}"
 
 # ── Check prerequisites ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Restructure the image build system around **target profiles** so adding a cloud (AWS Nitro, Azure CC, local TDX, etc.) is dropping a directory in, not forking scripts.

Each target lives at \`image/targets/<name>/profile.env\` — shell-sourceable KEY=VALUE with module set, root strategy, cmdline, output format, default memory/vCPU.

Two targets ship:

| Target | Format | Root strategy | Use case |
|--------|--------|---------------|----------|
| \`gcp\` | GPT disk | ext4-label + optional dm-verity | GCP TDX (default, unchanged behavior) |
| \`local-tdx\` | hybrid ISO with embedded ESP | iso9660 + squashfs + tmpfs overlay | Local QEMU+OVMF+TDX dev loop |

## What's new

- \`image/targets/<name>/profile.env\` — per-target config
- \`image/init-templates/{ext4-label,squashfs-overlay}.sh\` — \`/init\` scripts, one per root strategy
- \`image/lib/mkesp.sh\` — shared FAT32 ESP builder (used by both \`assemble-disk.sh\` and the ISO path)
- \`image/mkimage.sh\` — format dispatcher (disk vs iso)
- \`image/run-local-tdx.sh\` — QEMU+OVMF+TDX launcher that reads memory/vCPU defaults from the profile
- \`image/mkinitrd.sh\` — now profile-driven: reads \`TARGET_INITRD_MODULES\` and installs the strategy's init template

## Usage

\`\`\`bash
cd image
make build                   # defaults to TARGET=gcp
make build TARGET=local-tdx  # hybrid ISO
bash run-local-tdx.sh [agent.env]
\`\`\`

Output dirs are now \`image/output/<target>/\` so targets don't collide. \`.github/workflows/image.yml\` is updated to pick up GCP artifacts from \`image/output/gcp/\`.

## MRTD caveat (documented in README)

TDX measurements **differ per target and per launch site**. Local TDVF ≠ GCP's TDVF; local \`-m 4G -smp 2\` ≠ \`c3-standard-4\`; ISO UKI ≠ disk UKI. Don't cross-verify local quotes against GCP \`MEASUREMENTS.txt\`. Local-TDX is a dev convenience, not a production-attestation-equivalent artifact.

## Test plan

- [x] \`cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test\` stays green (no \`src/\` changes)
- [x] Shell scripts pass \`bash -n\`
- [x] \`make -n build TARGET=gcp\` / \`TARGET=local-tdx\` dry-runs produce sensible command sequences
- [ ] \`make build TARGET=gcp\` on CI produces byte-identical UKI to prior main (same cargo, same kernel, same modules, same cmdline)
- [ ] \`make build TARGET=local-tdx\` produces \`output/local-tdx/easyenclave.iso\`
- [ ] \`bash image/run-local-tdx.sh\` on a TDX host boots the ISO to easyenclave's "listening on" line

## Non-goals

- dm-verity on ISO (disk path has none either yet)
- Secure Boot signing
- CI matrix across targets (trivial follow-up once this lands)
- Capturing live TDX MRTDs per target (requires actually booting each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)