### PR TITLE
fix(ci): restore dns-from-dhcp log + fix CHECKS delimiter

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -183,19 +183,20 @@ jobs:
           SHA12: ${{ needs.build.outputs.sha12 }}
         run: |
           LABEL="${SHA12}"
+          # Use '|' as field delimiter so patterns can contain ':'.
           CHECKS=(
-            "kernel_boot:Run /init as init process:1"
-            "root_resolved:Resolved root to /dev/:1"
-            "easyenclave_pid1:easyenclave: running as PID 1:1"
-            "tmpfs_mounted:mounted /var/lib/easyenclave:1"
-            "cgroup_mounted:mounted /sys/fs/cgroup:1"
-            "tdx_attestation:attestation backend: tdx:1"
-            "network_up:Device link is up:1"
-            "dhcp_lease:lease of .* obtained:1"
-            "dns_configured:dns from dhcp lease:1"
-            "gce_metadata:gce-meta env:1"
-            "listening:easyenclave: listening on:1"
-            "deployment_running:deployment .* running:1"
+            "kernel_boot|Run /init as init process|1"
+            "root_resolved|Resolved root to /dev/|1"
+            "easyenclave_pid1|easyenclave: running as PID 1|1"
+            "tmpfs_mounted|mounted /var/lib/easyenclave|1"
+            "cgroup_mounted|mounted /sys/fs/cgroup|1"
+            "tdx_attestation|attestation backend: tdx|1"
+            "network_up|Device link is up|1"
+            "dhcp_lease|lease of .* obtained|1"
+            "dns_configured|dns from dhcp lease|1"
+            "gce_metadata|gce-meta env|1"
+            "listening|easyenclave: listening on|1"
+            "deployment_running|deployment .* running|1"
           )
 
           # Two native workloads: seed an index file, then serve it with
@@ -245,13 +246,13 @@ jobs:
               break
             fi
             for check in "${CHECKS[@]}"; do
-              IFS=: read -r name pattern required <<< "$check"
+              IFS="|" read -r name pattern required <<< "$check"
               [ -n "${PASSED[$name]:-}" ] && continue
               echo "$out" | grep -qE "$pattern" && PASSED[$name]=1 && echo "  ✓ $name"
             done
             ALL_REQUIRED_DONE=true
             for check in "${CHECKS[@]}"; do
-              IFS=: read -r name pattern required <<< "$check"
+              IFS="|" read -r name pattern required <<< "$check"
               [ "$required" = "0" ] && continue
               [ -z "${PASSED[$name]:-}" ] && ALL_REQUIRED_DONE=false && break
             done
@@ -280,7 +281,7 @@ jobs:
           echo "=== integration test (${LABEL}) ==="
           PASS=0; TOTAL=0
           for check in "${CHECKS[@]}"; do
-            IFS=: read -r name pattern required <<< "$check"
+            IFS="|" read -r name pattern required <<< "$check"
             [ "$required" = "1" ] && TOTAL=$((TOTAL + 1))
             if [ -n "${PASSED[$name]:-}" ]; then
               echo "  ✓ $name"

--- a/src/init.rs
+++ b/src/init.rs
@@ -183,6 +183,12 @@ pub fn maybe_init() {
             {
                 Ok(s) if s.success() => {
                     eprintln!("easyenclave: init: dhcp lease acquired");
+                    if std::fs::metadata("/run/resolv.conf")
+                        .map(|m| m.len() > 0)
+                        .unwrap_or(false)
+                    {
+                        eprintln!("easyenclave: init: dns from dhcp lease");
+                    }
                 }
                 Ok(s) => {
                     eprintln!("easyenclave: init: udhcpc exited with {s}");


### PR DESCRIPTION
## Summary
- Main's `Build & Release VM Image` is failing (run 24458059159, `8/10 passed`). Two bugs identified:
  - Commit 0e03f58 moved DHCP DNS writes into the udhcpc hook via `/run/resolv.conf` and removed the `easyenclave: init: dns from dhcp lease` eprintln from `src/init.rs`. The integration test's `dns_configured` check still greps for that string, so it never matched. Because `ALL_REQUIRED_DONE` gated the HTTP probe, `workload_http` was also skipped.
  - The `CHECKS` array uses `:` as the field delimiter, but three patterns contain `:` themselves (`easyenclave: running as PID 1`, `attestation backend: tdx`, `easyenclave: listening on`). With `IFS=: read -r name pattern required`, the trailing `required` field absorbs the rest of the pattern instead of being `1`, so those three checks were silently excluded from `TOTAL` — the display count was `8/10` instead of the expected `10/13`.
- Re-emit the log marker in `src/init.rs` after udhcpc succeeds when `/run/resolv.conf` has content.
- Switch the `CHECKS` delimiter to `|` in the array and the three `IFS=` read sites.

## Test plan
- [ ] `Build & Release VM Image` integration test turns green on this PR
- [ ] Post-merge, main run reaches `10/10 passed` (12 boot checks + HTTP once the delimiter fix is in, count is correct)
- [ ] Verify serial log shows `easyenclave: init: dns from dhcp lease` after DHCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)