### PR TITLE
Add ITA v2 report data attestation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,59 @@ Newline-delimited JSON over `/var/lib/easyenclave/agent.sock`:
 
 `attach` is the only method that changes the connection's protocol — after the JSON ack, the connection is a raw byte stream bridging a `script -qfc <cmd> /dev/null` PTY. Used by clients that want an interactive shell (dd-client, dd-web).
 
+For a Java workload example, see
+[`docs/confer-proxy-on-easyenclave.md`](docs/confer-proxy-on-easyenclave.md).
+
+### ITA v2 and verifier integration
+
+EasyEnclave is an evidence producer, not a verifier. The runtime intentionally
+does not carry Intel Trust Authority API keys, call ITA over the network, or
+make policy decisions inside PID 1. A relying party, dd-web/dd-register, or a
+small verifier sidecar should:
+
+1. Get freshness material from the verifier. For ITA v2 this can be
+   `GET https://api.trustauthority.intel.com/appraisal/v2/nonce`.
+2. Compute the 64-byte TDX `report_data` binding required by the verifier.
+   For ITA, use Intel's client adapter logic for the verifier nonce,
+   `runtime_data`, and any held data you include.
+3. Ask EasyEnclave for a quote:
+
+   ```json
+   {"method":"attest","report_data_b64":"<64-byte-report-data-base64>"}
+   ```
+
+4. Submit the returned `quote_b64` to ITA v2:
+
+   ```json
+   {
+     "tdx": {
+       "quote": "<quote_b64>",
+       "verifier_nonce": {"val":"...","iat":"...","signature":"..."}
+     },
+     "policy_ids": ["<policy-id>"],
+     "policy_must_match": true
+   }
+   ```
+
+The legacy `nonce` request field is still accepted. Hex-looking values are
+decoded as hex for existing tooling; other values are decoded as base64. New
+verifier integrations should use `report_data_b64` so the caller controls the
+exact TDX report-data bytes.
+
+### QGS boundary
+
+EasyEnclave does not talk to the Intel TDX Quote Generation Service directly.
+It uses the Linux `configfs-tsm` interface:
+
+```
+/sys/kernel/config/tsm/report/<report>/inblob
+/sys/kernel/config/tsm/report/<report>/outblob
+```
+
+If QGS is needed on a platform, it sits below that interface in the guest
+kernel, VMM, host, or cloud provider quote path. EasyEnclave only requires that
+`configfs-tsm` can produce a real TDX quote.
+
 ## Configuration
 
 `/etc/easyenclave/config.json` (optional, env vars override):

--- a/src/attestation/mod.rs
+++ b/src/attestation/mod.rs
@@ -7,10 +7,15 @@ pub trait AttestationBackend: Send + Sync {
     fn attestation_type(&self) -> &str;
 
     /// Generate a base64-encoded attestation quote, if available.
-    fn generate_quote_b64(&self) -> Option<String>;
+    fn generate_quote_b64(&self) -> Result<String, String>;
 
-    /// Generate a quote with caller-supplied nonce embedded in report data.
-    fn generate_quote_with_nonce(&self, nonce: &[u8]) -> Option<String>;
+    /// Generate a base64-encoded quote with caller-supplied report data.
+    ///
+    /// For TDX this is the raw TD report_data buffer before zero padding.
+    /// Callers that integrate an external verifier such as Intel Trust
+    /// Authority should compute that verifier's required report_data binding
+    /// outside the enclave runtime and pass it here.
+    fn generate_quote_with_report_data(&self, report_data: &[u8]) -> Result<String, String>;
 }
 
 /// Detect the attestation backend. Returns an error if no hardware

--- a/src/attestation/tsm.rs
+++ b/src/attestation/tsm.rs
@@ -1,6 +1,9 @@
 //! TDX quote generation via Linux configfs-tsm.
 
 use base64::Engine;
+use std::path::{Path, PathBuf};
+
+const TDX_REPORT_DATA_SIZE: usize = 64;
 
 /// Generate a TDX quote by writing user data to the configfs-tsm report
 /// interface and reading back the binary quote.
@@ -8,38 +11,54 @@ use base64::Engine;
 /// `report_root` -- path to the tsm report entry, e.g.
 /// `/sys/kernel/config/tsm/report/report0`.
 /// `user_data` -- up to 64 bytes that will be embedded as report data.
-fn generate_tdx_quote(report_root: &str, user_data: &[u8]) -> Result<Vec<u8>, String> {
+fn generate_tdx_quote(report_root: &Path, user_data: &[u8]) -> Result<Vec<u8>, String> {
     use std::fs;
-    use std::path::Path;
 
-    let root = Path::new(report_root);
+    if user_data.len() > TDX_REPORT_DATA_SIZE {
+        return Err(format!(
+            "TDX report data is {} bytes; maximum is {TDX_REPORT_DATA_SIZE}",
+            user_data.len()
+        ));
+    }
 
-    // Pad or truncate user data to exactly 64 bytes (configfs-tsm requirement).
-    let mut padded = [0u8; 64];
-    let copy_len = user_data.len().min(64);
-    padded[..copy_len].copy_from_slice(&user_data[..copy_len]);
+    // Pad user data to exactly 64 bytes (configfs-tsm requirement).
+    let mut padded = [0u8; TDX_REPORT_DATA_SIZE];
+    padded[..user_data.len()].copy_from_slice(user_data);
 
     // Write raw binary user data to the inblob file.
-    let inblob_path = root.join("inblob");
+    let inblob_path = report_root.join("inblob");
     fs::write(&inblob_path, padded).map_err(|e| format!("write inblob: {e}"))?;
 
     // Read the generated binary quote.
-    let outblob_path = root.join("outblob");
+    let outblob_path = report_root.join("outblob");
     fs::read(&outblob_path).map_err(|e| format!("read outblob: {e}"))
+}
+
+struct ReportDir {
+    path: PathBuf,
+}
+
+impl ReportDir {
+    fn create(path: PathBuf) -> Result<Self, String> {
+        std::fs::create_dir_all(&path).map_err(|e| format!("create tsm report dir: {e}"))?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for ReportDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
 }
 
 /// Generate a TDX quote with the given user data and return it base64-encoded.
 fn generate_tdx_quote_base64(user_data: &[u8]) -> Result<String, String> {
     // Create a unique report entry under configfs-tsm.
     let report_name = format!("report_{}", uuid::Uuid::new_v4().as_simple());
-    let report_root = format!("/sys/kernel/config/tsm/report/{report_name}");
+    let report_root = PathBuf::from(format!("/sys/kernel/config/tsm/report/{report_name}"));
 
-    std::fs::create_dir_all(&report_root).map_err(|e| format!("create tsm report dir: {e}"))?;
-
-    let quote_bytes = generate_tdx_quote(&report_root, user_data)?;
-
-    // Clean up.
-    let _ = std::fs::remove_dir_all(&report_root);
+    let report_dir = ReportDir::create(report_root)?;
+    let quote_bytes = generate_tdx_quote(&report_dir.path, user_data)?;
 
     Ok(base64::engine::general_purpose::STANDARD.encode(&quote_bytes))
 }
@@ -52,11 +71,11 @@ impl super::AttestationBackend for TdxBackend {
         "tdx"
     }
 
-    fn generate_quote_b64(&self) -> Option<String> {
-        generate_tdx_quote_base64(&[]).ok()
+    fn generate_quote_b64(&self) -> Result<String, String> {
+        generate_tdx_quote_base64(&[])
     }
 
-    fn generate_quote_with_nonce(&self, nonce: &[u8]) -> Option<String> {
-        generate_tdx_quote_base64(nonce).ok()
+    fn generate_quote_with_report_data(&self, report_data: &[u8]) -> Result<String, String> {
+        generate_tdx_quote_base64(report_data)
     }
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -134,28 +134,104 @@ async fn handle_health(
 }
 
 fn handle_attest(req: &Value, attestation: &Arc<Box<dyn AttestationBackend>>) -> Value {
-    let nonce_b64 = req.get("nonce").and_then(|n| n.as_str()).unwrap_or("");
-    let nonce_bytes = if nonce_b64.is_empty() {
-        Vec::new()
-    } else {
-        use base64::Engine;
-        match base64::engine::general_purpose::STANDARD.decode(nonce_b64) {
-            Ok(bytes) => bytes,
-            Err(e) => return json!({"ok": false, "error": format!("invalid nonce base64: {e}")}),
-        }
+    let report_data = match attestation_report_data(req) {
+        Ok(report_data) => report_data,
+        Err(e) => return json!({"ok": false, "error": e}),
     };
 
-    let quote = if nonce_bytes.is_empty() {
+    let quote = if report_data.is_empty() {
         attestation.generate_quote_b64()
     } else {
-        attestation.generate_quote_with_nonce(&nonce_bytes)
+        attestation.generate_quote_with_report_data(&report_data)
     };
 
     match quote {
-        Some(q) => json!({"ok": true, "quote_b64": q}),
-        None => {
-            json!({"ok": true, "quote_b64": null, "attestation_type": attestation.attestation_type()})
+        Ok(q) => {
+            use base64::Engine;
+            json!({
+                "ok": true,
+                "attestation_type": attestation.attestation_type(),
+                "quote_format": "tdx",
+                "quote_b64": q,
+                "report_data_b64": base64::engine::general_purpose::STANDARD.encode(&report_data),
+                "report_data_len": report_data.len(),
+            })
         }
+        Err(e) => json!({
+            "ok": false,
+            "attestation_type": attestation.attestation_type(),
+            "error": e,
+        }),
+    }
+}
+
+fn attestation_report_data(req: &Value) -> Result<Vec<u8>, String> {
+    let report_data =
+        if let Some(report_data_b64) = req.get("report_data_b64").and_then(|n| n.as_str()) {
+            decode_base64_field("report_data_b64", report_data_b64)?
+        } else if let Some(nonce) = req.get("nonce").and_then(|n| n.as_str()) {
+            decode_legacy_nonce(nonce)?
+        } else {
+            Vec::new()
+        };
+
+    if report_data.len() > 64 {
+        return Err(format!(
+            "TDX report data is {} bytes; maximum is 64",
+            report_data.len()
+        ));
+    }
+
+    Ok(report_data)
+}
+
+fn decode_base64_field(field: &str, value: &str) -> Result<Vec<u8>, String> {
+    if value.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD
+        .decode(value)
+        .map_err(|e| format!("invalid {field} base64: {e}"))
+}
+
+fn decode_legacy_nonce(value: &str) -> Result<Vec<u8>, String> {
+    if is_hex(value) {
+        decode_hex(value).map_err(|e| format!("invalid nonce hex: {e}"))
+    } else {
+        decode_base64_field("nonce", value)
+    }
+}
+
+fn is_hex(value: &str) -> bool {
+    !value.is_empty()
+        && value.len().is_multiple_of(2)
+        && value.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+fn decode_hex(value: &str) -> Result<Vec<u8>, String> {
+    if !value.len().is_multiple_of(2) {
+        return Err("odd number of digits".into());
+    }
+
+    value
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let high = hex_value(pair[0])?;
+            let low = hex_value(pair[1])?;
+            Ok((high << 4) | low)
+        })
+        .collect()
+}
+
+fn hex_value(byte: u8) -> Result<u8, String> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'a'..=b'f' => Ok(byte - b'a' + 10),
+        b'A'..=b'F' => Ok(byte - b'A' + 10),
+        _ => Err(format!("non-hex digit '{}'", byte as char)),
     }
 }
 
@@ -379,5 +455,54 @@ async fn handle_logs(req: &Value, deployments: &Deployments) -> Value {
     match crate::process::read_logs(&app_name, tail).await {
         Ok(lines) => json!({"ok": true, "lines": lines}),
         Err(e) => json!({"ok": false, "error": e}),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+    use serde_json::json;
+
+    #[test]
+    fn report_data_b64_is_preferred() {
+        let report_data = vec![1u8; 32];
+        let req = json!({
+            "report_data_b64": base64::engine::general_purpose::STANDARD.encode(&report_data),
+            "nonce": "00",
+        });
+
+        assert_eq!(attestation_report_data(&req).unwrap(), report_data);
+    }
+
+    #[test]
+    fn legacy_nonce_accepts_base64() {
+        let nonce = b"freshness";
+        let req = json!({
+            "nonce": base64::engine::general_purpose::STANDARD.encode(nonce),
+        });
+
+        assert_eq!(attestation_report_data(&req).unwrap(), nonce);
+    }
+
+    #[test]
+    fn legacy_nonce_accepts_hex_values() {
+        let req = json!({ "nonce": "deadbeef" });
+
+        assert_eq!(
+            attestation_report_data(&req).unwrap(),
+            vec![0xde, 0xad, 0xbe, 0xef]
+        );
+    }
+
+    #[test]
+    fn report_data_rejects_oversize_values() {
+        let report_data = vec![7u8; 65];
+        let req = json!({
+            "report_data_b64": base64::engine::general_purpose::STANDARD.encode(report_data),
+        });
+
+        let err = attestation_report_data(&req).unwrap_err();
+        assert!(err.contains("maximum is 64"));
     }
 }


### PR DESCRIPTION
Summary:
- Add explicit report_data_b64 quote generation for verifier-controlled TDX report_data.
- Return attestation errors instead of silently returning null quotes.
- Document direct ITA v2 integration, QGS boundaries, and confer-proxy packaging for EasyEnclave.

Verification:
- rustfmt --edition 2021 --check src/socket.rs src/attestation/mod.rs src/attestation/tsm.rs
- cargo test not run locally: existing untracked src/lib.rs makes Cargo infer a broken library target, and Linux-target verification on this macOS host lacks x86_64-linux-gnu-gcc.