### PR TITLE
feat(capture): tee workload stdio to a unix-domain capture socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
+ "tempfile",
  "tokio",
  "ureq",
  "uuid",
@@ -141,6 +142,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
@@ -783,6 +790,19 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.1",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ tokio = { version = "1", features = ["macros", "process", "rt-multi-thread", "si
 # webpki-roots; we don't depend on system CA certs.
 ureq = { version = "2", default-features = false, features = ["tls", "json"] }
 uuid = { version = "1", features = ["serde", "v4"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1,0 +1,160 @@
+//! Workload stdio capture — optionally tee every spawned workload's
+//! stdout/stderr to a unix-domain socket as line-delimited JSON
+//! records.
+//!
+//! When a [`workload::DeployRequest`](crate::workload::DeployRequest)
+//! sets `capture_socket`, easyenclave connects to that socket once per
+//! spawned workload and sends:
+//!
+//! - `{"type":"spawn","id":"<app>-<ms>","argv":[..],"cwd":"/"}` — first
+//! - `{"type":"out","id":"<app>-<ms>","s":"stdout"|"stderr","b":"<line>"}`
+//!   — per line, in order of arrival. `b` is the UTF-8 string (no base64).
+//! - `{"type":"exit","id":"<app>-<ms>","code":<i32>}` — last, before
+//!   closing the connection.
+//!
+//! The consumer on the other end of the socket (today:
+//! `devopsdefender/dd`'s bastion workload) can reconstruct each
+//! workload's lifetime into a searchable block. If the socket isn't
+//! there or the connection drops mid-stream, easyenclave keeps the
+//! workload running — capture is best-effort tee, not a hard
+//! dependency.
+
+use std::path::Path;
+use std::sync::Arc;
+use tokio::io::AsyncWriteExt;
+use tokio::net::UnixStream;
+use tokio::sync::Mutex;
+
+/// A live connection to the capture socket for a single workload.
+///
+/// Clone cheaply for each tee task (stdout + stderr share one
+/// connection under a mutex); consume the last handle via
+/// [`CaptureSink::exit`] to emit the final record and drop the socket.
+#[derive(Clone)]
+pub struct CaptureSink {
+    stream: Arc<Mutex<UnixStream>>,
+    id: Arc<str>,
+}
+
+impl CaptureSink {
+    /// Connect to `path`, send the initial `spawn` record, and return
+    /// a handle usable for `out` and `exit` calls.
+    ///
+    /// Returns `None` on any I/O error so callers can fall back to
+    /// running the workload without capture rather than failing it.
+    pub async fn connect(
+        path: impl AsRef<Path>,
+        id: String,
+        argv: &[String],
+        cwd: Option<&str>,
+    ) -> Option<Self> {
+        let stream = match UnixStream::connect(path.as_ref()).await {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!(
+                    "easyenclave: capture socket {}: {e} — skipping capture for {id}",
+                    path.as_ref().display()
+                );
+                return None;
+            }
+        };
+        let sink = Self {
+            stream: Arc::new(Mutex::new(stream)),
+            id: Arc::from(id),
+        };
+        let record = serde_json::json!({
+            "type": "spawn",
+            "id": &*sink.id,
+            "argv": argv,
+            "cwd": cwd,
+        });
+        if sink.send(record).await.is_err() {
+            return None;
+        }
+        Some(sink)
+    }
+
+    /// Send an `out` record for one line of stdout/stderr.
+    pub async fn out(&self, stream_name: &str, line: &str) {
+        let record = serde_json::json!({
+            "type": "out",
+            "id": &*self.id,
+            "s": stream_name,
+            "b": line,
+        });
+        let _ = self.send(record).await;
+    }
+
+    /// Send the final `exit` record and close. Takes `self` so callers
+    /// can't keep using the sink after exit.
+    pub async fn exit(self, code: i32) {
+        let record = serde_json::json!({
+            "type": "exit",
+            "id": &*self.id,
+            "code": code,
+        });
+        let _ = self.send(record).await;
+        // UnixStream closes on drop.
+    }
+
+    async fn send(&self, record: serde_json::Value) -> std::io::Result<()> {
+        let mut line = serde_json::to_string(&record).unwrap_or_default();
+        line.push('\n');
+        let mut g = self.stream.lock().await;
+        g.write_all(line.as_bytes()).await?;
+        g.flush().await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    use tokio::net::UnixListener;
+
+    #[tokio::test]
+    async fn emits_spawn_out_exit_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("capture.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+
+        let accept = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut lines = BufReader::new(stream).lines();
+            let mut out = Vec::new();
+            while let Ok(Some(line)) = lines.next_line().await {
+                out.push(line);
+            }
+            out
+        });
+
+        let sink = CaptureSink::connect(
+            &sock,
+            "myapp-42".into(),
+            &["myapp".into(), "--flag".into()],
+            None,
+        )
+        .await
+        .expect("connect");
+        sink.out("stdout", "hello").await;
+        sink.out("stderr", "boom").await;
+        sink.exit(7).await;
+
+        let lines = accept.await.unwrap();
+        assert_eq!(lines.len(), 4);
+        let spawn: serde_json::Value = serde_json::from_str(&lines[0]).unwrap();
+        assert_eq!(spawn["type"], "spawn");
+        assert_eq!(spawn["id"], "myapp-42");
+        assert_eq!(spawn["argv"], serde_json::json!(["myapp", "--flag"]));
+        let out1: serde_json::Value = serde_json::from_str(&lines[1]).unwrap();
+        assert_eq!(out1["type"], "out");
+        assert_eq!(out1["s"], "stdout");
+        assert_eq!(out1["b"], "hello");
+        let out2: serde_json::Value = serde_json::from_str(&lines[2]).unwrap();
+        assert_eq!(out2["s"], "stderr");
+        let exit: serde_json::Value = serde_json::from_str(&lines[3]).unwrap();
+        assert_eq!(exit["type"], "exit");
+        assert_eq!(exit["code"], 7);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod attestation;
+mod capture;
 mod config;
 mod init;
 mod process;

--- a/src/process.rs
+++ b/src/process.rs
@@ -4,6 +4,9 @@ use std::path::PathBuf;
 use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
+use tokio::task::JoinHandle;
+
+use crate::capture::CaptureSink;
 
 const LOG_DIR: &str = "/var/lib/easyenclave/workloads/logs";
 
@@ -18,7 +21,9 @@ fn spawn_tee(
     stream: impl tokio::io::AsyncRead + Unpin + Send + 'static,
     log_file: std::fs::File,
     prefix: String,
-) {
+    capture: Option<CaptureSink>,
+    stream_name: &'static str,
+) -> JoinHandle<()> {
     use std::io::Write;
     use std::sync::Mutex;
     let log_file = std::sync::Arc::new(Mutex::new(log_file));
@@ -30,21 +35,35 @@ fn spawn_tee(
                 let _ = writeln!(f, "{line}");
                 let _ = f.flush();
             }
+            if let Some(c) = capture.as_ref() {
+                c.out(stream_name, &line).await;
+            }
         }
-    });
+    })
 }
 
 /// Spawn a command directly on the VM. stdout+stderr are piped, drained
 /// by background tasks, and tee'd to both a per-app log file (for the
 /// `logs` socket method) and easyenclave's own stderr (so output is
 /// visible on the serial console during boot).
+/// Handle to a spawned workload. `tee_handles` are the background tasks
+/// draining stdout/stderr into the log file (and the capture socket, if
+/// configured). Await them before emitting a final `exit` record so the
+/// child's last lines aren't lost to the race between `child.wait()` and
+/// pipe drain.
+pub struct SpawnedChild {
+    pub child: Child,
+    pub tee_handles: Vec<JoinHandle<()>>,
+}
+
 pub async fn spawn_command(
     program: &str,
     args: &[&str],
     tty: bool,
     app_name: &str,
-) -> Result<Child, String> {
-    spawn_inner(program, args, tty, None, app_name).await
+    capture: Option<CaptureSink>,
+) -> Result<SpawnedChild, String> {
+    spawn_inner(program, args, tty, None, app_name, capture).await
 }
 
 /// Spawn a command with an explicit environment map on top of the
@@ -55,8 +74,9 @@ pub async fn spawn_command_with_env(
     tty: bool,
     env: &std::collections::HashMap<String, String>,
     app_name: &str,
-) -> Result<Child, String> {
-    spawn_inner(program, args, tty, Some(env), app_name).await
+    capture: Option<CaptureSink>,
+) -> Result<SpawnedChild, String> {
+    spawn_inner(program, args, tty, Some(env), app_name, capture).await
 }
 
 async fn spawn_inner(
@@ -65,7 +85,8 @@ async fn spawn_inner(
     tty: bool,
     env: Option<&std::collections::HashMap<String, String>>,
     app_name: &str,
-) -> Result<Child, String> {
+    capture: Option<CaptureSink>,
+) -> Result<SpawnedChild, String> {
     std::fs::create_dir_all(LOG_DIR).map_err(|e| format!("create log dir: {e}"))?;
     let log_file =
         std::fs::File::create(log_path(app_name)).map_err(|e| format!("open log: {e}"))?;
@@ -105,14 +126,27 @@ async fn spawn_inner(
     let pid = child.id().unwrap_or(0);
     eprintln!("easyenclave: spawned {program} (pid={pid}, app={app_name})");
 
+    let mut tee_handles = Vec::with_capacity(2);
     if let Some(stdout) = child.stdout.take() {
-        spawn_tee(stdout, log_file, app_name.to_string());
+        tee_handles.push(spawn_tee(
+            stdout,
+            log_file,
+            app_name.to_string(),
+            capture.clone(),
+            "stdout",
+        ));
     }
     if let Some(stderr) = child.stderr.take() {
-        spawn_tee(stderr, log_clone, app_name.to_string());
+        tee_handles.push(spawn_tee(
+            stderr,
+            log_clone,
+            app_name.to_string(),
+            capture,
+            "stderr",
+        ));
     }
 
-    Ok(child)
+    Ok(SpawnedChild { child, tee_handles })
 }
 
 /// Read the last `tail` lines from a workload's log file.

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -12,10 +12,18 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
+use crate::capture::CaptureSink;
 use crate::process;
 use crate::release::{self, GithubRelease};
 
 const BIN_DIR: &str = "/var/lib/easyenclave/bin";
+
+/// Reads `EE_CAPTURE_SOCKET`; when set, every spawned workload's
+/// stdin/stdout is teed to this unix-domain socket as LDJSON records.
+/// See [`capture`](crate::capture).
+fn capture_socket_path() -> Option<PathBuf> {
+    std::env::var_os("EE_CAPTURE_SOCKET").map(PathBuf::from)
+}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct DeploymentInfo {
@@ -146,15 +154,49 @@ async fn spawn_from_cmd(
     };
     let args: Vec<&str> = req.cmd.iter().skip(1).map(|s| s.as_str()).collect();
 
+    // If EE_CAPTURE_SOCKET is set, open a per-workload connection to it
+    // and emit a `spawn` record before the child starts. The sink is
+    // cloned into the tee tasks (so each stdout/stderr line becomes an
+    // `out` record) and moved into the wait task (so we emit `exit`
+    // when the child terminates). A failed connect falls back to
+    // running without capture — best-effort tee, not a hard dependency.
+    let capture = if let Some(sock) = capture_socket_path() {
+        let id = format!(
+            "{}-{}",
+            app_name,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis())
+                .unwrap_or(0)
+        );
+        let argv: Vec<String> = std::iter::once(program_owned.clone())
+            .chain(args.iter().map(|s| s.to_string()))
+            .collect();
+        CaptureSink::connect(&sock, id, &argv, None).await
+    } else {
+        None
+    };
+
     let result = if let Some(env_list) = &req.env {
         let env_map = parse_env_list(env_list);
-        process::spawn_command_with_env(&program_owned, &args, req.tty, &env_map, app_name).await
+        process::spawn_command_with_env(
+            &program_owned,
+            &args,
+            req.tty,
+            &env_map,
+            app_name,
+            capture.clone(),
+        )
+        .await
     } else {
-        process::spawn_command(&program_owned, &args, req.tty, app_name).await
+        process::spawn_command(&program_owned, &args, req.tty, app_name, capture.clone()).await
     };
 
     match result {
-        Ok(mut child) => {
+        Ok(process::SpawnedChild {
+            mut child,
+            tee_handles,
+        }) => {
             let pid = child.id();
             eprintln!("easyenclave: deployment {dep_id} running (pid={pid:?})");
             let mut deps = deployments.lock().await;
@@ -164,7 +206,18 @@ async fn spawn_from_cmd(
             }
             drop(deps);
             tokio::spawn(async move {
-                let _ = child.wait().await;
+                let status = child.wait().await;
+                // Wait for the tee tasks to finish draining stdout/stderr
+                // before emitting the final `exit` record — otherwise a
+                // workload's last lines lose the race and get committed
+                // after the block's closing bookmark.
+                for h in tee_handles {
+                    let _ = h.await;
+                }
+                if let Some(sink) = capture {
+                    let code = status.ok().and_then(|s| s.code()).unwrap_or(-1);
+                    sink.exit(code).await;
+                }
             });
         }
         Err(e) => set_deploy_failed(deployments, dep_id, &e).await,


### PR DESCRIPTION
## Summary

When `EE_CAPTURE_SOCKET=/path/to/sock` is set, easyenclave opens one connection per spawned workload to that socket and writes LDJSON records:

```json
{"type":"spawn","id":"<app>-<ms>","argv":[..],"cwd":null}
{"type":"out","id":"<app>-<ms>","s":"stdout","b":"<line>"}
{"type":"exit","id":"<app>-<ms>","code":<i32>}
```

The consumer on the other end can reconstruct each workload's lifetime into a searchable block. Zero change when the env var is unset.

## Why

DevOps Defender is building a block-aware terminal (`bastion`) whose sidebar wants a "Workloads" section alongside interactive shells — each workload shown as a `{command, output, exit}` record with full-text search. Rather than teach easyenclave about bastion, we tee stdin/stdout to a socket and let bastion own the parsing + storage.

## Design notes

- **One connection per workload lifetime.** Connection opens on spawn, closes after `exit`. The `id` (`<app_name>-<ms>`) lets the consumer correlate records.
- **Best-effort tee.** Failed connect or mid-stream drop ⇒ easyenclave keeps the workload running without capture. Not a hard dependency — good for single-node dev and for the moment before the consumer socket is up.
- **Exit record waits for drain.** The tee tasks are `JoinHandle`s; the wait task awaits `child.wait()`, then joins both tees, then emits `exit` — so the child's last lines don't lose the race with `wait()`.
- **No new config file surface.** Env-var only, so consumers (including in-workspace `systemd`-like setups) can opt in per-instance. Easy to extend to a per-`DeployRequest` knob later if needed; chose not to expand the public API on day one.

## Known limitations (not blocking this PR, documenting for review)

- `BufReader::lines()` drops a stream on invalid UTF-8 (this is pre-existing behavior of the `spawn_tee` log path). Workloads emitting binary framing or truncated escapes will have their remainder lost from both the log file and the capture. Fixing needs `read_until(b'\n') + from_utf8_lossy`, worth a follow-up.
- Grandchild fds (fork+setsid, exec with `>&file`) bypass the pipe. Acceptable for DD's workload set; eBPF fallback is a later option if we ever need it.
- `cwd` is always `null` in the `spawn` record — easyenclave doesn't configure per-workload cwd today. Left hook in the protocol so a future `DeployRequest.cwd` can populate it without a schema bump.

## Test plan

- [x] Unit test in `src/capture.rs`: binds a unix listener, connects a sink, sends `out`/`exit`, asserts the four LDJSON records match.
- [x] `cargo build` + `cargo test` clean.
- [ ] Integration: downstream consumer (bastion) reports workload blocks populate once this lands + `EE_CAPTURE_SOCKET` is baked into the workload env.