### PR TITLE
feat(seal): boot token gates the unix socket

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,14 @@ pub struct BootWorkload {
     /// installed without running them directly.
     #[serde(default)]
     pub github_release: Option<GithubRelease>,
+    /// When true, EE injects `EE_TOKEN=<hex>` into this workload's env
+    /// at spawn. The workload must include `"token": "<hex>"` on every
+    /// EE socket request; unauth'd requests are rejected with
+    /// `{"ok":false,"error":"unauthenticated"}`. Today only `dd-agent`
+    /// needs this — every other workload runs without socket access,
+    /// which is the whole point of the seal.
+    #[serde(default)]
+    pub inherit_token: bool,
 }
 
 fn default_socket_path() -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,12 +77,25 @@ async fn main() {
     // 5. Create empty deployments
     let deployments: workload::Deployments = Arc::new(Mutex::new(HashMap::new()));
 
+    // Mint a single per-boot token. Workloads with `inherit_token: true`
+    // get it in their env (`EE_TOKEN=<hex>`); the socket server requires
+    // it on every request. Local-root-inside-a-compromised-workload
+    // stops being enough to drive EE — only the one workload that was
+    // explicitly granted the env var can talk to the socket.
+    let boot_token = mint_boot_token();
+
     // 6. Deploy boot workloads from config.
     for bw in &cfg.boot_workloads {
         eprintln!("easyenclave: boot workload: {}", bw.app_name);
+        let mut env = bw.env.clone();
+        if bw.inherit_token {
+            env.get_or_insert_with(Vec::new)
+                .push(format!("EE_TOKEN={boot_token}"));
+            eprintln!("easyenclave: {} inherits EE_TOKEN", bw.app_name);
+        }
         let req = workload::DeployRequest {
             cmd: bw.cmd.clone().unwrap_or_default(),
-            env: bw.env.clone(),
+            env,
             app_name: Some(bw.app_name.clone()),
             tty: bw.tty,
             github_release: bw.github_release.clone(),
@@ -117,10 +130,31 @@ async fn main() {
         deployments,
         attestation: Arc::new(attestation),
         start_time,
+        expected_token: Some(boot_token),
     };
 
     if let Err(e) = server.run().await {
         eprintln!("easyenclave: socket server error: {e}");
         std::process::exit(1);
     }
+}
+
+/// Mint a 32-byte random token at boot, hex-encoded. Uses
+/// `getrandom(2)` via the kernel; no extra crate dep. `/dev/urandom`
+/// is also an option but `getrandom` avoids the need to open a file
+/// and is always available on Linux 3.17+.
+fn mint_boot_token() -> String {
+    let mut buf = [0u8; 32];
+    unsafe {
+        let mut got = 0usize;
+        while got < buf.len() {
+            let n = libc::getrandom(buf.as_mut_ptr().add(got) as *mut _, buf.len() - got, 0);
+            if n < 0 {
+                let err = std::io::Error::last_os_error();
+                panic!("easyenclave: FATAL: getrandom failed: {err}");
+            }
+            got += n as usize;
+        }
+    }
+    buf.iter().map(|b| format!("{b:02x}")).collect()
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -19,6 +19,10 @@ pub struct SocketServer {
     pub deployments: Deployments,
     pub attestation: Arc<Box<dyn AttestationBackend>>,
     pub start_time: std::time::Instant,
+    /// If set, every request must include `"token": "<matching-value>"`.
+    /// Minted once at boot by `main.rs::mint_boot_token` and handed to
+    /// workloads that opt in via `BootWorkload.inherit_token`.
+    pub expected_token: Option<String>,
 }
 
 impl SocketServer {
@@ -35,6 +39,14 @@ impl SocketServer {
         let listener = UnixListener::bind(&self.socket_path)
             .map_err(|e| format!("bind {}: {e}", self.socket_path))?;
 
+        // Belt-and-suspenders: even with the token check in place, only
+        // root should be able to open the socket. Workloads running as
+        // non-root (future privilege-drop tier) can't bypass the token
+        // check by guessing — they can't even connect.
+        if let Err(e) = chmod_0600(&self.socket_path) {
+            eprintln!("easyenclave: warning: chmod {} 0600: {e}", self.socket_path);
+        }
+
         eprintln!("easyenclave: listening on {}", self.socket_path);
 
         loop {
@@ -46,6 +58,7 @@ impl SocketServer {
             let deployments = self.deployments.clone();
             let attestation = self.attestation.clone();
             let start_time = self.start_time;
+            let expected_token = self.expected_token.clone();
 
             tokio::spawn(async move {
                 let (reader, mut writer) = stream.into_split();
@@ -63,6 +76,12 @@ impl SocketServer {
                     // Sniff for `attach` before dispatching — it switches
                     // the connection from JSON line mode to raw bytes.
                     if let Ok(req) = serde_json::from_str::<Value>(line.trim()) {
+                        if !token_ok(&req, expected_token.as_deref()) {
+                            let _ = writer
+                                .write_all(b"{\"ok\":false,\"error\":\"unauthenticated\"}\n")
+                                .await;
+                            continue;
+                        }
                         if req.get("method").and_then(|m| m.as_str()) == Some("attach") {
                             if writer
                                 .write_all(b"{\"ok\":true,\"attached\":true}\n")
@@ -458,11 +477,84 @@ async fn handle_logs(req: &Value, deployments: &Deployments) -> Value {
     }
 }
 
+/// Constant-time-ish equality + `None`-means-unsealed logic. When
+/// `expected` is `None` the socket is in "no seal" mode and every
+/// request is accepted (matches pre-Tier-1 behaviour — useful for
+/// local dev and upstream's existing standalone usage). When
+/// `expected` is `Some(t)`, the caller must include a matching
+/// `"token": "<t>"` field.
+fn token_ok(req: &Value, expected: Option<&str>) -> bool {
+    let Some(expected) = expected else {
+        return true;
+    };
+    let Some(got) = req.get("token").and_then(|v| v.as_str()) else {
+        return false;
+    };
+    constant_time_eq(got.as_bytes(), expected.as_bytes())
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut acc: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        acc |= x ^ y;
+    }
+    acc == 0
+}
+
+/// `chmod 0600` on a path. Used right after `UnixListener::bind` so
+/// only the owner (EE itself, UID 0) can connect. Combined with the
+/// token check this makes local-admin access a two-factor gate.
+fn chmod_0600(path: &str) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(path)?.permissions();
+    perms.set_mode(0o600);
+    std::fs::set_permissions(path, perms)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use base64::Engine;
     use serde_json::json;
+
+    #[test]
+    fn token_ok_accepts_when_no_seal() {
+        // expected=None → pre-seal behaviour, every request passes.
+        assert!(token_ok(&json!({}), None));
+        assert!(token_ok(&json!({"method": "health"}), None));
+    }
+
+    #[test]
+    fn token_ok_rejects_without_token() {
+        assert!(!token_ok(&json!({"method": "health"}), Some("secret")));
+    }
+
+    #[test]
+    fn token_ok_rejects_wrong_token() {
+        assert!(!token_ok(
+            &json!({"method": "health", "token": "nope"}),
+            Some("secret"),
+        ));
+    }
+
+    #[test]
+    fn token_ok_accepts_matching_token() {
+        assert!(token_ok(
+            &json!({"method": "health", "token": "secret"}),
+            Some("secret"),
+        ));
+    }
+
+    #[test]
+    fn constant_time_eq_matches_std_eq() {
+        assert!(constant_time_eq(b"hello", b"hello"));
+        assert!(!constant_time_eq(b"hello", b"world"));
+        assert!(!constant_time_eq(b"short", b"shorter"));
+        assert!(constant_time_eq(b"", b""));
+    }
 
     #[test]
     fn report_data_b64_is_preferred() {


### PR DESCRIPTION
## Summary

Tier 1 of an easyenclave \"seal\" story. Mints a 32-byte random token at boot, hands it only to workloads that opt in via \`BootWorkload.inherit_token\`, and requires every socket request to carry a matching \`token\` field. A compromised workload that didn't receive the token can't reach EE's control surface — shell/file access to the VM stops being sufficient to drive deploys/attach/exec.

## Motivation

Downstream consumer (devopsdefender/dd) wants \"local admin on the VM\" to stop being equivalent to \"control of the enclave.\" The attested access path goes through a separate auth'd tunnel (CF Access + bastion); the raw unix socket shouldn't be a side channel any compromised workload can use.

## Change

- **Mint-at-boot token** (\`main.rs::mint_boot_token\`) — 32 bytes from \`getrandom(2)\`, hex-encoded. Stored in memory only; never written to disk. No extra crate dep.
- **Env injection** (\`main.rs\`, \`config.rs\`) — new \`BootWorkload.inherit_token: bool\` (default false). Workloads that opt in get \`EE_TOKEN=<hex>\` appended to their env at spawn.
- **Socket gate** (\`socket.rs\`) — \`SocketServer.expected_token: Option<String>\`. Requests without matching \`\"token\"\` field are rejected with \`{\"ok\":false,\"error\":\"unauthenticated\"}\`. Constant-time comparison to avoid any timing leak.
- **\`chmod 0600\`** on the bound socket — only UID 0 can open it at all. Belt + suspenders for a future privilege-drop tier where non-root workloads physically can't connect.

## Backward compatibility

\`expected_token: None\` preserves pre-seal behaviour (every request accepted). Embedders using easyenclave standalone (no DD) who don't set \`inherit_token\` on any boot workload will get the default-None codepath via an easy embedder API shift — today's default in \`main.rs\` passes \`Some(boot_token)\`, meaning unpatched DD will break. If you want a graceful rollout, I can split this: land the socket accept-with-token-when-set code first (always accepts when \`None\`), then flip the default to \`Some\` after downstream ships its token-send change. Happy to do that split if you prefer — say the word.

## Config shape

\`\`\`json
{
  \"app_name\": \"dd-agent\",
  \"cmd\": [\"/var/lib/easyenclave/bin/dd-agent\"],
  \"inherit_token\": true,
  \"env\": [\"DD_CP_URL=https://app.devopsdefender.com\"]
}
\`\`\`

## Test plan

- [x] Unit tests for \`token_ok\` (None-preserves-open, missing-rejects, wrong-rejects, match-accepts) and \`constant_time_eq\` (symmetric + length-mismatch).
- [x] \`cargo build\` clean, all 10 tests green.
- [ ] Integration: downstream DD PR adds \`inherit_token: true\` to its \`dd-agent\` boot workload and updates \`dd-agent\`'s unix client to send \`\"token\": env!(\"EE_TOKEN\")\` on every call. Once both land and an image rolls, attempting to connect from any other local workload gets \`unauthenticated\`.