### PR TITLE
fix(capture): 1s timeout on CaptureSink::connect + deploy diagnostics

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -255,12 +255,21 @@ fn hex_value(byte: u8) -> Result<u8, String> {
 }
 
 async fn handle_deploy(req: &Value, deployments: &Deployments) -> Value {
+    let app_preview = req
+        .get("app_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("(none)");
+    eprintln!("easyenclave: handle_deploy entered (app={app_preview})");
     let deploy_req: DeployRequest = match serde_json::from_value(req.clone()) {
         Ok(r) => r,
-        Err(e) => return json!({"ok": false, "error": format!("invalid deploy request: {e}")}),
+        Err(e) => {
+            eprintln!("easyenclave: handle_deploy parse error: {e}");
+            return json!({"ok": false, "error": format!("invalid deploy request: {e}")});
+        }
     };
 
     let (id, status) = crate::workload::execute_deploy(deployments, deploy_req).await;
+    eprintln!("easyenclave: handle_deploy → id={id} status={status}");
     json!({"ok": true, "id": id, "status": status})
 }
 

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -160,6 +160,11 @@ async fn spawn_from_cmd(
     // `out` record) and moved into the wait task (so we emit `exit`
     // when the child terminates). A failed connect falls back to
     // running without capture — best-effort tee, not a hard dependency.
+    //
+    // Bounded by a 1-second timeout: if the consumer on the other end
+    // of the socket hangs (not-yet-accepted or accepted-but-not-reading),
+    // we give up and spawn the workload without capture rather than
+    // wedging every subsequent deploy behind a stalled socket.
     let capture = if let Some(sock) = capture_socket_path() {
         let id = format!(
             "{}-{}",
@@ -172,7 +177,20 @@ async fn spawn_from_cmd(
         let argv: Vec<String> = std::iter::once(program_owned.clone())
             .chain(args.iter().map(|s| s.to_string()))
             .collect();
-        CaptureSink::connect(&sock, id, &argv, None).await
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            CaptureSink::connect(&sock, id.clone(), &argv, None),
+        )
+        .await
+        {
+            Ok(sink) => sink,
+            Err(_) => {
+                eprintln!(
+                    "easyenclave: capture connect for {app_name} timed out after 1s — running uncaptured"
+                );
+                None
+            }
+        }
     } else {
         None
     };


### PR DESCRIPTION
## Summary

Two small changes to unblock a downstream DD investigation.

## 1. Bound \`CaptureSink::connect\` at 1s

\`workload::spawn_from_cmd\` awaits \`CaptureSink::connect(...).await\` synchronously before spawning the child process. If the consumer on the other end of \`EE_CAPTURE_SOCKET\` is slow to accept or accepted-but-not-reading, that await stalls the \`run_deploy\` task forever — and any subsequent workload spawn queued up behind it also hangs.

Wrap in \`tokio::time::timeout(Duration::from_secs(1), ...)\`. On expiry, log a warning and fall back to spawning the workload uncaptured. Same graceful-degradation semantics as a straight connect-failure (which already short-circuits in \`CaptureSink::connect\`).

## 2. Trace the deploy path

Two eprintlns in \`handle_deploy\` — entry and outcome — so downstream operators (DD, specifically) can tell from \`/logs/dd-agent\` whether a \`/deploy\` request actually reached EE's handler vs. stalling upstream (dd-agent's GH OIDC verifier, axum extractors, the token check, JSON parse, etc.). Right now DD is seeing empty-body 2xx responses on \`POST /deploy\` with no visible stack trace either side — these logs will disambiguate.

## Context

DD (\`devopsdefender/dd#172\` is the current active PR) consumes EE's \`EE_CAPTURE_SOCKET\` as a real-time push feed to bastion. Bastion recently gained a pull-based fallback via EE's \`list\`+\`logs\` socket methods, but live push is still preferred. A slow bastion listener shouldn't wedge EE's whole spawn path, which is what today's unbounded \`.connect().await\` risks.

## Test plan

- [x] \`cargo test\` — 10 passed, 0 failed.
- [x] \`cargo fmt\` clean.
- [ ] Downstream verification: rebuild DD's next preview against the new EE image; \`Deploy hello-world\` in CI should either now succeed, or at minimum the \`/logs/dd-agent\` tail will show which side the stall happens on.