### PR TITLE
Add dependabot, CODEOWNERS, SECURITY.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default reviewer for all changes.
+* @posix4e

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  # Cargo deps — keep the runtime's crate tree current. Weekly so we
+  # don't drown in bumps but still notice CVEs within a week.
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      # Group tokio/serde family PRs so they land together — these
+      # ecosystems tend to bump in lockstep and splitting them creates
+      # dependency-resolution churn.
+      tokio-ecosystem:
+        patterns:
+          - "tokio*"
+          - "futures*"
+      serde-ecosystem:
+        patterns:
+          - "serde*"
+
+  # Action pin updates. We pin actions/checkout@v4, dtolnay/rust-toolchain
+  # etc. by major version; dependabot proposes specific-sha pins when it
+  # sees new majors.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Report privately through GitHub's security advisory form:
+https://github.com/easyenclave/easyenclave/security/advisories/new
+
+Do not open a public issue for security bugs.
+
+## Scope
+
+EasyEnclave is a runtime that boots inside an Intel TDX confidential VM
+and exposes a unix-socket API for workload management. The highest-priority
+classes of issue:
+
+- **Attestation integrity** — paths that fabricate or bypass a TDX quote,
+  skip `configfs-tsm`, or allow a non-TDX host to answer as if attested.
+- **Boot-chain integrity** — anything that weakens the measured-boot
+  chain (UKI, initrd, dm-verity) or lets the sealed rootfs be modified
+  between measurement and execution.
+- **Socket authorization** — bypasses of the `EE_TOKEN` gate on the
+  agent socket, or escalation from a compromised workload to socket
+  authority it wasn't granted.
+- **Metadata-plane injection** — paths where cloud metadata (`ee-config`,
+  customData) or the secondary config disk can push arbitrary env into
+  PID 1 in a way the platform's trust model didn't intend.
+
+## What to include
+
+- Commit / release tag affected
+- Minimal reproduction (serial log, quote payload, or test commit)
+- Threat model you're operating under (what the attacker can/can't do)
+
+## Non-scope
+
+- Crashes during boot on non-TDX hardware — intentional (`detect()`
+  refuses to proceed without TDX)
+- DoS from an authorized workload misbehaving — workloads are trusted
+  code running inside the enclave
+
+## Response
+
+Acknowledgement within 72 hours, triage within a week.


### PR DESCRIPTION
Three repo-hygiene files, independent of PR #83. No code changes.

## Summary

- **`.github/dependabot.yml`** — weekly cargo + github-actions updates. Tokio and serde families grouped so they land together rather than creating resolver churn. Max 5 open PRs per ecosystem.
- **`.github/CODEOWNERS`** — default reviewer @posix4e on all paths.
- **`SECURITY.md`** — GitHub private advisory form as the report channel; scope list prioritizes attestation integrity, boot-chain integrity, socket authorization, metadata injection. Out-of-scope explicit: non-TDX crashes (by design) and in-enclave workload DoS.

Branched off `main` so PR #83 is unaffected.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(".github/dependabot.yml"))'` — YAML parses
- [ ] Post-merge: Dependabot picks up the config on its next poll (usually within an hour), first weekly PRs land next Monday
- [ ] CODEOWNERS: first PR after merge shows @posix4e auto-requested as reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)