### PR TITLE
feat(image): add local-tdx-qcow2 target for libvirt backing files

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -70,7 +70,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [gcp, azure, local-tdx]
+        # local-tdx-qcow2: a GPT-disk qcow2 with the `qemu` vendor stage —
+        # libvirt-backing-file shape for `devopsdefender/dd` et al. Same
+        # rootfs build as `gcp`, but without the GCE IMDS probe. Not in
+        # the tdx-smoke matrix because its boot chain is all already
+        # covered by `local-tdx` (squashfs/ISO) + `gcp` (GPT/ext4) and
+        # dd's preview-deploy smokes it end-to-end against a real
+        # workload on every release.
+        target: [gcp, azure, local-tdx, local-tdx-qcow2]
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,16 @@ Artifacts land in `image/output/<target>/`.
 | `gcp` | `gcp` (IMDS `ee-config`) | GPT disk | ext4 label + optional dm-verity | `easyenclave.root.raw`, `easyenclave.qcow2`, `easyenclave-gcp.tar.gz` | GCP TDX compute images (default) |
 | `azure` | `azure` (IMDS `customData`) | GPT disk | ext4 label + optional dm-verity | `easyenclave.root.raw`, `easyenclave.vhd` | Azure TDX CVMs — import the VHD into a Shared Image Gallery or Managed Disk |
 | `local-tdx` | `qemu` (secondary config disk) | hybrid ISO with embedded ESP | iso9660 + squashfs + tmpfs overlay | `easyenclave.iso`, `rootfs.squashfs` | Local QEMU/OVMF TDX boot for dev iteration |
+| `local-tdx-qcow2` | `qemu` (secondary config disk) | GPT disk | ext4 label + optional dm-verity | `easyenclave.root.raw`, `easyenclave.qcow2` | libvirt backing-file shape (`devopsdefender/dd` et al) — persistent base qcow2, COW overlay per VM |
 
 Build:
 
 ```bash
 cd image
-make build                   # defaults to TARGET=gcp
-make build TARGET=azure      # Azure fixed-size VHD
-make build TARGET=local-tdx  # hybrid ISO for local TDX
+make build                         # defaults to TARGET=gcp
+make build TARGET=azure            # Azure fixed-size VHD
+make build TARGET=local-tdx        # hybrid ISO for local TDX
+make build TARGET=local-tdx-qcow2  # qcow2 backing file for libvirt
 ```
 
 For local launch, boot `image/output/local-tdx/easyenclave.iso` with a TDX-capable QEMU/TDVF or libvirt setup. If you need boot-time config, attach a second read-only disk or CD-ROM with `/agent.env`; PID 1 probes `/dev/vdb` and `/dev/sdb` for `iso9660`, `ext4`, `vfat`, or `ext2` config media.

--- a/image/targets/local-tdx-qcow2/profile.env
+++ b/image/targets/local-tdx-qcow2/profile.env
@@ -1,0 +1,28 @@
+# Local TDX VM target — GPT disk with ext4 rootfs, qemu vendor stage.
+#
+# Variant of the `gcp` profile for operators running directly on a
+# local TDX host via libvirt. Same root strategy (ext4 label on GPT,
+# writable) as gcp so libvirt can COW-clone the qcow2 per VM; but the
+# `qemu` vendor stage (no GCE IMDS probe, no Azure customData fetch —
+# reads config off a secondary disk or kernel cmdline). `devopsdefender`
+# consumes the qcow2 as the backing file under
+# /var/lib/libvirt/images/easyenclave-local.qcow2 and creates per-VM
+# overlays on top.
+#
+# If you're spinning up a one-shot dev VM via `run-local-tdx.sh`, use
+# the `local-tdx` ISO target instead — smaller footprint, no writable
+# root. This target exists for the persistent-base libvirt workflow.
+
+TARGET_FORMAT=disk
+TARGET_ROOT_STRATEGY=ext4-label
+TARGET_VENDOR=qemu
+TARGET_CMDLINE="root=LABEL=root console=ttyS0,115200"
+
+# No gve or cloud-network drivers; virtio throughout under libvirt/qemu.
+TARGET_INITRD_MODULES="dm-verity nvme tdx-guest tsm-report virtio_net virtio_blk virtio_pci virtio_scsi"
+
+# `disk` format always yields efi + raw + qcow2 when qcow2 is listed.
+TARGET_OUTPUTS="efi raw qcow2"
+
+TARGET_DEFAULT_MEM=4G
+TARGET_DEFAULT_VCPU=2


### PR DESCRIPTION
## Why

`devopsdefender/dd` runs TDX VMs on a bare-metal libvirt host (tdx2). Its `apps/_infra/local-agents.sh` + `local-cp.sh` expect a qcow2 at `/var/lib/libvirt/images/easyenclave-local.qcow2` and `qemu-img create -b` per-VM COW overlays on top of it. Until now that file had to be hand-built from the `gcp` target — which meant every libvirt VM booted with `gcp.sh` as its initrd vendor stage and spent its first 30s waiting for `http://169.254.169.254/computeMetadata/v1/instance/attributes/ee-config` to time out before proceeding.

With the vendor split from #83, that's fixable: bake a qcow2 with `qemu.sh` (no metadata probe) instead.

## What

One new target profile `image/targets/local-tdx-qcow2/profile.env`:

- **Format:** `disk` (ext4-label on GPT — same as `gcp`, so `qemu-img create -b` overlays work)
- **Vendor:** `qemu` (reads config from secondary disk / cmdline — no IMDS)
- **Modules:** virtio-only, no `gve`
- **Outputs:** `efi raw qcow2`

Plus:
- `.github/workflows/image.yml` — adds `local-tdx-qcow2` to the `build` matrix. Not added to `tdx-smoke` because the boot chain is already covered by `gcp` (GPT/ext4) and `local-tdx` (ISO/squashfs); dd's preview-deploy workflow exercises this artifact end-to-end against a real workload on every release.
- `README.md` targets table + build-examples.

## Why not just extend `local-tdx`

That target is `TARGET_FORMAT=iso` with `squashfs-overlay` root strategy — incompatible shape for libvirt backing files. The Makefile + `mkimage.sh` already handle both `disk` and `iso` formats cleanly, so a new target is just a profile + one matrix entry.

## Downstream

Once this merges, every staging / stable release on easyenclave will publish `easyenclave-<sha12>-local-tdx-qcow2.qcow2` as a release asset. A follow-up PR on `devopsdefender/dd` auto-syncs that file onto tdx2 by channel:

- dd `production` → `easyenclave-stable` channel
- dd `preview` / pr-N → `easyenclave-staging` channel

No longer a hand-managed file on the host.

## Test plan

- [ ] Push this branch — CI builds the new target and uploads the artifact. Verify `easyenclave-*-local-tdx-qcow2.qcow2` appears in the workflow's artifacts.
- [ ] Local: `cd image && make build TARGET=local-tdx-qcow2` produces `image/output/local-tdx-qcow2/easyenclave.qcow2`.
- [ ] `qemu-img info easyenclave.qcow2` → format qcow2, virtual size matches the ext4 disk raw.
- [ ] Merge → next staging release includes the new asset.
- [ ] dd-side sync PR consumes it; preview deploy boots on tdx2 with no 30s IMDS stall post-DHCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)