### PR TITLE
fix(init): persist DHCP resolv.conf into newroot

### DIFF
--- a/image/init-templates/vendors/_lib.sh
+++ b/image/init-templates/vendors/_lib.sh
@@ -44,8 +44,29 @@ ee_ifup() {
         udhcpc -i "$iface" -q -n -t 10 \
             -s /usr/share/udhcpc/default.script \
             -O staticroutes 2>&1 | tail -n 3 || :
+        # The udhcpc hook writes DHCP-provided nameservers to
+        # /tmp/resolv.conf.udhcpc (and tries /run/resolv.conf, which fails
+        # silently — see below). Both paths live in the *initrd* fs and
+        # are wiped by switch_root, so the newroot's /etc/resolv.conf
+        # (symlinked to /run/resolv.conf by mkosi.postinst.chroot) ends
+        # up pointing at an empty tmpfs. Splice the hook's output into
+        # $NEWROOT/run so it survives the switch.
+        #
+        # Using `cat >` redirection rather than `cp`: mkinitrd.sh doesn't
+        # symlink `cp` to busybox, so `cp` would exit 127 "not found".
+        # `cat` is in the symlink list. (This also explains why the hook's
+        # own `cp ... "$RESOLV" || true` has been a silent no-op.)
+        if [ -f /tmp/resolv.conf.udhcpc ]; then
+            mkdir -p "$NEWROOT/run"
+            if cat /tmp/resolv.conf.udhcpc > "$NEWROOT/run/resolv.conf" 2>/dev/null; then
+                ee_log "dns from dhcp → $NEWROOT/run/resolv.conf"
+            else
+                ee_log "splice dhcp resolv.conf failed"
+            fi
+        fi
     fi
 
+    # EE_DNS (static override from cmdline/config-disk) wins over DHCP.
     dns=$(ee_env_get EE_DNS || true)
     if [ -n "$dns" ]; then
         ee_log "static dns=$dns"


### PR DESCRIPTION
## Summary
- **DD production v0.2.0 deploy failure**: CP VM boots, attestation OK, then cloudflared pre-fetch dies with `Dns Failed: resolve dns name 'api.github.com:443'`. Serial log: [dd run 24889967728](https://github.com/devopsdefender/dd/actions/runs/24889967728)
- **Root cause**: the vendor-split refactor (#83) moved DHCP from PID 1 into the initrd vendor stage but dropped the bind-mount dance from #61 that carried DHCP-learned nameservers across `switch_root`. The udhcpc hook writes `/tmp/resolv.conf.udhcpc` in the initrd; that fs is wiped on switch_root; the newroot's `/etc/resolv.conf` is a symlink to `/run/resolv.conf` (empty tmpfs) — PID 1 sees no DNS.
- **Fix**: in `ee_ifup`, after udhcpc returns, splice `/tmp/resolv.conf.udhcpc` into `$NEWROOT/run/resolv.conf` so it lives through the switch. `EE_DNS` static override still wins.

## Secondary find
The udhcpc hook's own `cp /tmp/resolv.conf.udhcpc "$RESOLV"` has been a silent no-op all along — `cp` isn't in the initrd's busybox symlink list (`image/mkinitrd.sh` line ~60), so the command exits 127 and `|| true` hides it. The new code uses `cat >` redirection (`cat` *is* symlinked) to dodge that trap.

## Test plan
- [x] `bash -n` / `busybox sh -n` on `_lib.sh`
- [x] `busybox sh image/ci-test-vendor-lib.sh` (10/10)
- [ ] CI matrix green (gcp + azure + local-tdx-qcow2 real-TDX smoke)
- [ ] Tag new patch release, re-run DD production deploy, confirm `/run/resolv.conf` gets populated and cloudflared fetch succeeds

## Follow-up (separate PR)
Smoke-test blind spot: busybox-httpd doesn't resolve hostnames, so no vendor smoke exercises DNS. Adding a `wget https://...` assertion (or a workload that hits a URL) would catch this class of regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)