### PR TITLE
ci(azure): plug VM + disk cleanup leaks, add scheduled sweep

### DIFF
--- a/.github/workflows/cleanup-azure-smoke.yml
+++ b/.github/workflows/cleanup-azure-smoke.yml
@@ -1,0 +1,86 @@
+name: Cleanup Azure smoke orphans
+
+# Backstop sweep for ee-smoke-* resources left behind by
+# build-and-smoke (azure) runs. The smoke script's own trap cleanup
+# handles the happy path; this workflow covers the pathological cases
+# (runner hard-kill, cleanup exception, future naming-drift) before
+# they pile up against the WestUS3 Regional Cores quota.
+#
+# Safe to run any time: the 2-hour age threshold is well past the
+# ~25-min smoke budget, so an in-flight job's resources won't be
+# swept out from under it.
+
+on:
+  schedule:
+    # 12:00 UTC daily. Once per day is plenty — each smoke run creates
+    # ~7 resources and at steady state zero should survive past the
+    # trap cleanup. The cron is a safety net, not the primary path.
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+# Serialize: if cron + a manual dispatch collide, one waits.
+concurrency:
+  group: cleanup-azure-smoke
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Sweep stale ee-smoke-* resources
+        env:
+          AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
+        run: |
+          set -euo pipefail
+          threshold=$(( $(date +%s) - 7200 ))
+          echo "cleanup: threshold=$threshold ($(date -u -d @$threshold '+%Y-%m-%dT%H:%MZ'))"
+
+          # Resource names follow ee-smoke-${SHA12}-${STAMP}-{suffix}
+          # from image/ci-tdx-smoke-azure.sh. Field 4 (dash-split) is
+          # the unix epoch stamp; compare against the 2h threshold.
+          # Using the embedded stamp (rather than Azure's
+          # properties.timeCreated, which isn't uniform across resource
+          # types) keeps this deterministic and auditable.
+          az resource list --resource-group "$AZURE_RESOURCE_GROUP" \
+              --query "[?starts_with(name, 'ee-smoke-')].{name:name, id:id}" \
+              -o json > /tmp/resources.json
+          total=$(jq 'length' /tmp/resources.json)
+          echo "cleanup: found $total ee-smoke-* resources total"
+
+          jq -r --argjson t "$threshold" '
+            .[]
+            | select(((.name | split("-"))[3] // "0") | tonumber < $t)
+            | "\(.id)\t\(.name)"
+          ' /tmp/resources.json > /tmp/stale.tsv
+
+          stale=$(wc -l < /tmp/stale.tsv)
+          echo "cleanup: $stale are older than 2h (will be deleted)"
+          cat /tmp/stale.tsv | sed 's/^/  [stale] /'
+
+          if [ "$stale" -eq 0 ]; then
+            echo "cleanup: nothing to do"
+            exit 0
+          fi
+
+          # --verbose so each delete's ARM response is visible in the
+          # run log. Continue on individual failures (|| true at the
+          # xargs level would swallow them — instead, let the batch
+          # fail if ALL deletes fail, but the set +e inside the loop
+          # means one failure doesn't stop the rest).
+          set +e
+          failed=0
+          while IFS=$'\t' read -r id name; do
+            echo "cleanup: deleting $name"
+            az resource delete --ids "$id" --verbose || failed=$((failed + 1))
+          done < /tmp/stale.tsv
+          echo "cleanup: complete ($((stale - failed))/$stale succeeded, $failed failed)"
+          [ "$failed" -eq "$stale" ] && exit 1 || exit 0

--- a/image/ci-tdx-smoke-azure.sh
+++ b/image/ci-tdx-smoke-azure.sh
@@ -79,12 +79,23 @@ BLOB_NAME="${PREFIX}.vhd"
 
 cleanup() {
     set +e
+    # Guard against a pre-PREFIX exit (e.g. someone rearranges the script
+    # and moves the trap above PREFIX=). Without this, `az ... --name ""`
+    # could match unintended resources or produce confusing errors.
+    [ -n "${PREFIX:-}" ] || return 0
     echo "smoke:azure: cleanup"
-    az vm delete --resource-group "$AZURE_RESOURCE_GROUP" --name "$VM_NAME" --yes --no-wait 2>/dev/null || true
-    sleep 10
+    # VM delete WITHOUT --no-wait: we need Azure to at least ACK the
+    # delete request before this script exits. Previously --no-wait +
+    # runner-kill could leave the DELETE un-posted, orphaning the VM
+    # (and its cores). The wait is ~30-60s, well within budget.
+    # Dropped 2>/dev/null on every cleanup line (keeping || true) so
+    # real cleanup failures surface in the CI log — the earlier silent
+    # swallow masked the managed-disk + NIC orphans that eventually
+    # filled the WestUS3 cores quota.
+    az vm delete --resource-group "$AZURE_RESOURCE_GROUP" --name "$VM_NAME" --yes || true
     az sig image-version delete --resource-group "$AZURE_RESOURCE_GROUP" \
         --gallery-name "$GALLERY_NAME" --gallery-image-definition "$IMG_DEF_NAME" \
-        --gallery-image-version "$IMG_VERSION" --no-wait 2>/dev/null || true
+        --gallery-image-version "$IMG_VERSION" --no-wait || true
     # ACCT_KEY may be unset if we exited before fetching it; fetch again
     # (cheap: az handles the no-op case), fall back to nothing if the
     # account itself is gone.
@@ -93,12 +104,22 @@ cleanup() {
         --query '[0].value' -o tsv 2>/dev/null || true)
     if [ -n "$CLEANUP_KEY" ]; then
         az storage blob delete --account-name "$STORAGE_ACCT" --container-name "$STORAGE_CONTAINER" \
-            --name "$BLOB_NAME" --account-key "$CLEANUP_KEY" 2>/dev/null || true
+            --name "$BLOB_NAME" --account-key "$CLEANUP_KEY" || true
     fi
-    az network nic delete --resource-group "$AZURE_RESOURCE_GROUP" --name "$NIC_NAME" --no-wait 2>/dev/null || true
-    az network public-ip delete --resource-group "$AZURE_RESOURCE_GROUP" --name "$PIP_NAME" --no-wait 2>/dev/null || true
-    az network nsg delete --resource-group "$AZURE_RESOURCE_GROUP" --name "$NSG_NAME" --no-wait 2>/dev/null || true
-    az network vnet delete --resource-group "$AZURE_RESOURCE_GROUP" --name "$VNET_NAME" --no-wait 2>/dev/null || true
+    az network nic delete --resource-group "$AZURE_RESOURCE_GROUP" --name "$NIC_NAME" --no-wait || true
+    az network public-ip delete --resource-group "$AZURE_RESOURCE_GROUP" --name "$PIP_NAME" --no-wait || true
+    az network nsg delete --resource-group "$AZURE_RESOURCE_GROUP" --name "$NSG_NAME" --no-wait || true
+    az network vnet delete --resource-group "$AZURE_RESOURCE_GROUP" --name "$VNET_NAME" --no-wait || true
+
+    # Belt-and-suspenders: any resource whose name starts with our
+    # per-run PREFIX that the named deletes above missed (future
+    # naming drift, partial writes, resource types added to the
+    # script without a matching cleanup line). --no-wait so runner
+    # timeout doesn't kill mid-sweep.
+    echo "smoke:azure: prefix sweep for ${PREFIX}-*"
+    az resource list --resource-group "$AZURE_RESOURCE_GROUP" \
+        --query "[?starts_with(name, '${PREFIX}')].id" -o tsv 2>/dev/null \
+      | xargs -r az resource delete --ids --verbose || true
 }
 trap cleanup EXIT
 
@@ -290,6 +311,8 @@ az vm create \
     --enable-vtpm true --enable-secure-boot false \
     --image "$IMG_VERSION_ID" \
     --nics "$NIC_NAME" \
+    --os-disk-delete-option Delete \
+    --nic-delete-option Delete \
     --boot-diagnostics-storage "https://${STORAGE_ACCT}.blob.core.windows.net/" \
     --admin-username eeci \
     --generate-ssh-keys \


### PR DESCRIPTION
## Summary

Preventive fix for the WestUS3 cores quota exhaustion that blocked image releases earlier today. The RG was manually nuked to reclaim quota, but the cleanup bugs in `image/ci-tdx-smoke-azure.sh` would leak again on the next failed smoke run.

### Fixes in the smoke script

- **`az vm create`**: add `--os-disk-delete-option Delete` + `--nic-delete-option Delete`. Azure's default is "Detach" → managed OS disk and NIC orphan after `az vm delete`. Now they auto-remove atomically with the VM.
- **`az vm delete`**: drop `--no-wait` so Azure acks the request before the script exits (~30–60s extra, well within budget). Prior `--no-wait` + runner hard-kill could leave the DELETE un-posted.
- **All cleanup commands**: drop `2>/dev/null` (keep `|| true`). Real failures surface in CI logs instead of silently rotting.
- **Prefix sweep**: after the named-delete sequence, `az resource list | xargs az resource delete --ids` catches anything the named deletes missed (partial writes, future naming drift, resource types added without a matching cleanup line).
- **Defensive guard**: `cleanup()` early-returns if `$PREFIX` is unset. Protects against future rearrangements accidentally calling `az ... --name ""`.

### New scheduled workflow

`.github/workflows/cleanup-azure-smoke.yml`:
- Daily `cron: '0 12 * * *'` + `workflow_dispatch`.
- Lists `ee-smoke-*` in `$AZURE_RESOURCE_GROUP`, parses the embedded unix-timestamp from field 4 of the name, deletes any older than 2h.
- Using the name-embedded stamp (not `properties.timeCreated`, which isn't uniform across resource types) keeps the logic deterministic and auditable.
- 2h threshold is well past the ~25-min smoke budget → no risk of sweeping an in-flight job.
- Idempotent: clean RG → zero deletions → zero log noise.

## Test plan

- [ ] Manual `workflow_dispatch` of `cleanup-azure-smoke.yml` on a clean RG: expect "nothing to do" in the log
- [ ] Next main push triggers `build-and-smoke (azure)`: watch for the `prefix sweep for ee-smoke-...` line at the end of cleanup, and for cleanup errors no longer being silenced
- [ ] After that run, `az resource list --resource-group ee-ci-westus3 --query "[?starts_with(name,'ee-smoke-')].name"` should be empty
- [ ] Intentional failure test (optional): interrupt a smoke run mid-VM-create; verify the prefix sweep catches any partial-write orphans

## Out of scope

- Azure quota increase from Microsoft. 10 cores in WestUS3 is tight for 2-vCPU TDX SKUs with any concurrency; separate support ticket.
- Restructuring `release: needs: [meta, build-and-smoke, gcp-promote]` so `local-tdx-qcow2` can ship even when azure/gcp cloud targets are red. Bigger change; follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)