### PR TITLE
Skip GCE metadata fetch off GCE and add GPU image-size blog

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -252,8 +252,14 @@ fn nix_mount_ro(src: &str, target: &str, fstype: &str) -> Result<(), String> {
 /// JSON array) is how you get easyenclave to deploy workloads at boot
 /// on a GCE VM — no secondary disk needed.
 ///
-/// On non-GCE hosts, or if the attribute isn't set, fail silently.
+/// Short-circuits on non-GCE hosts by sniffing DMI sys_vendor — the
+/// local libvirt VMs (tdx2) get `sys_vendor=QEMU`, so firing the 2s
+/// HTTP timeout at every boot is wasted time and noisy serial log.
 fn fetch_gce_metadata_config() {
+    if !is_gce_host() {
+        eprintln!("easyenclave: init: skipping gce-meta fetch (not on GCE)");
+        return;
+    }
     const URL: &str = "http://169.254.169.254/computeMetadata/v1/instance/attributes/ee-config";
     let body = match ureq::get(URL)
         .set("Metadata-Flavor", "Google")
@@ -290,6 +296,35 @@ fn fetch_gce_metadata_config() {
     for (k, v) in map {
         std::env::set_var(k, v);
     }
+}
+
+/// Cheap GCE detection via DMI. GCE sets both `sys_vendor` and
+/// `bios_vendor` to `"Google"`; local QEMU libvirt hosts (tdx2,
+/// dev laptops) report `"QEMU"`. If neither file is readable we
+/// fall back to attempting the fetch — safer to waste 2s than to
+/// silently skip a real GCE config.
+fn is_gce_host() -> bool {
+    for path in [
+        "/sys/class/dmi/id/sys_vendor",
+        "/sys/class/dmi/id/bios_vendor",
+    ] {
+        if let Ok(v) = std::fs::read_to_string(path) {
+            if v.trim().eq_ignore_ascii_case("Google") {
+                return true;
+            }
+        }
+    }
+    // Couldn't prove GCE — but couldn't prove non-GCE either if
+    // both reads failed. Check once more: if sys_vendor IS readable
+    // and says something that clearly isn't Google, trust that.
+    if let Ok(v) = std::fs::read_to_string("/sys/class/dmi/id/sys_vendor") {
+        let v = v.trim();
+        if !v.is_empty() && !v.eq_ignore_ascii_case("Google") {
+            return false;
+        }
+    }
+    // Fallback: attempt the fetch. It'll 2s-timeout off-GCE.
+    true
 }
 
 fn nix_mount_flags(

--- a/www/index.html
+++ b/www/index.html
@@ -15,6 +15,7 @@
     <a href="#whats-inside">What's Inside</a>
     <a href="#features">Features</a>
     <a href="#how">How It Works</a>
+    <a href="#blog">Blog</a>
     <a href="https://github.com/easyenclave/easyenclave">GitHub</a>
   </div>
 </nav>
@@ -103,6 +104,36 @@
   </div>
 </section>
 
+<section id="blog" class="ct">
+  <div class="c">
+    <h2>Blog</h2>
+    <p class="sub">Notes on minimal images, measured boot, and practical confidential computing.</p>
+    <div class="blog-list">
+      <article id="blog-nvidia-confidential-gpu" class="post featured-post">
+        <div class="meta">April 30, 2026 / Confidential GPUs</div>
+        <h3>NVIDIA Confidential GPU Support Turns a 50MB Linux Image Into 7GB</h3>
+        <p class="lede">To utilize NVIDIA's confidential GPU code with CUDA and LLMs, the minimum Linux installation grows from about 50MB to roughly 7GB after compression. Uncompressed and unsquashed, it is about twice that size.</p>
+        <div class="size-callout">
+          <div><span>50MB</span><small>minimal CPU image</small></div>
+          <div><span>7GB</span><small>compressed CUDA/LLM image</small></div>
+          <div><span>~14GB</span><small>uncompressed rootfs</small></div>
+        </div>
+        <p>The increase is not mostly application code. It is the GPU compute stack: CUDA libraries, PyTorch wheels, NVIDIA driver components, vLLM dependencies, and the operating-system pieces needed to support driver loading and kernel integration.</p>
+        <div class="breakdown">
+          <div class="bd-row"><span>CUDA 12.8 libraries</span><span>~2.5GB</span></div>
+          <div class="bd-row"><span>PyTorch wheels with bundled CUDA</span><span>~2GB</span></div>
+          <div class="bd-row"><span>NVIDIA 580 driver, fabricmanager, nscq, persistenced</span><span>~700MB</span></div>
+          <div class="bd-row"><span>vLLM and Python dependencies</span><span>~500MB</span></div>
+          <div class="bd-row"><span>Kernel, headers, modules, and systemd baggage</span><span>~200MB</span></div>
+          <div class="bd-row"><span>Ubuntu base and DKMS toolchain</span><span>~500MB</span></div>
+        </div>
+        <p>That is the tradeoff EasyEnclave is trying to make visible: confidential computing can be tiny when the workload is a static native binary, but confidential GPU inference currently pulls in a full accelerator ecosystem.</p>
+        <p class="commit-note">Latest commit: <code>7e40204</code> skips GCE metadata fetches on non-GCE hosts via DMI detection, reducing noisy boot logs on local QEMU and TDX development machines.</p>
+      </article>
+    </div>
+  </div>
+</section>
+
 <section id="api" class="ct">
   <div class="c">
     <h2>Socket API</h2>
@@ -148,6 +179,7 @@ bash test-local.sh</pre>
     <a href="https://github.com/easyenclave/easyenclave">GitHub</a>
     <a href="https://github.com/easyenclave/easyenclave#socket-api">API</a>
     <a href="https://github.com/easyenclave/easyenclave/wiki">Docs</a>
+    <a href="#blog">Blog</a>
   </p>
   <p style="margin-top:8px">EasyEnclave &mdash; MIT License</p>
 </footer>

--- a/www/style.css
+++ b/www/style.css
@@ -45,6 +45,23 @@ section h2 { font-size: 24px; font-weight: 700; margin-bottom: 10px; }
 .arch pre { font-family: var(--mono); font-size: 12px; line-height: 1.7; color: var(--dim); }
 .arch .g { color: var(--green); } .arch .b { color: var(--blue); }
 
+.blog-list { max-width: 680px; margin: 0 auto; text-align: left; }
+.post { background: var(--bg-alt); border: 1px solid var(--surface); border-radius: 10px; padding: 24px; }
+.post .meta { font-family: var(--mono); font-size: 11px; color: var(--green); font-weight: 600; margin-bottom: 8px; text-transform: uppercase; letter-spacing: .04em; }
+.post h3 { font-size: 22px; line-height: 1.25; margin-bottom: 12px; }
+.post p { color: var(--dim); font-size: 14px; margin-top: 14px; }
+.post .lede { color: var(--text); font-size: 16px; }
+.size-callout { display: grid; grid-template-columns: repeat(3,1fr); gap: 10px; margin: 22px 0; }
+.size-callout div { background: var(--surface); border-radius: 8px; padding: 14px; text-align: center; }
+.size-callout span { display: block; color: var(--green); font-family: var(--mono); font-size: 26px; font-weight: 800; line-height: 1; }
+.size-callout small { display: block; color: var(--dim); font-size: 12px; margin-top: 8px; line-height: 1.35; }
+.breakdown { border: 1px solid var(--surface); border-radius: 8px; overflow: hidden; margin-top: 18px; }
+.bd-row { display: grid; grid-template-columns: minmax(0,1fr) 96px; background: var(--bg); border-top: 1px solid var(--surface); }
+.bd-row:first-child { border-top: 0; }
+.bd-row span { padding: 10px 12px; color: var(--dim); font-size: 13px; }
+.bd-row span:last-child { color: var(--green); font-family: var(--mono); font-weight: 700; text-align: right; }
+.commit-note { border-top: 1px solid var(--surface); padding-top: 14px; }
+
 .api { display: grid; grid-template-columns: repeat(auto-fit,minmax(340px,1fr)); gap: 10px; }
 .ae { background: var(--bg-alt); border: 1px solid var(--surface); border-radius: 8px; padding: 14px; }
 .ae .l { font-family: var(--mono); font-size: 11px; color: var(--green); font-weight: 600; margin-bottom: 6px; }
@@ -75,4 +92,4 @@ section h2 { font-size: 24px; font-weight: 700; margin-bottom: 10px; }
 footer { border-top: 1px solid var(--surface); padding: 24px; text-align: center; }
 footer p { color: var(--dim); font-size: 13px; } footer a { color: var(--dim); margin: 0 10px; }
 
-@media(max-width:600px) { nav .links{display:none} .hero{padding:64px 16px 40px} .grid,.api{grid-template-columns:1fr} .stats{gap:24px} .cmp-hdr,.cmp-row{grid-template-columns:1fr 1fr 1fr; font-size:11px} .cmp-hdr span,.cmp-row span{padding:6px 8px} }
+@media(max-width:600px) { nav .links{display:none} .hero{padding:64px 16px 40px} .grid,.api,.size-callout{grid-template-columns:1fr} .stats{gap:24px} .cmp-hdr,.cmp-row{grid-template-columns:1fr 1fr 1fr; font-size:11px} .cmp-hdr span,.cmp-row span{padding:6px 8px} .post{padding:18px} .post h3{font-size:19px} .bd-row{grid-template-columns:1fr} .bd-row span:last-child{text-align:left; padding-top:0} }


### PR DESCRIPTION
## Summary
- skip GCE metadata fetches on non-GCE hosts using DMI vendor detection
- add a website blog section with the first post on NVIDIA confidential GPU image-size overhead
- include the rough compressed size breakdown for CUDA, PyTorch, NVIDIA driver components, vLLM dependencies, kernel/systemd pieces, and Ubuntu/DKMS tooling

## Testing
- not run; static HTML/CSS and init-path logic only